### PR TITLE
support for arbitrary source terms using aux flow fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_get_variable(PETSC_CXX_COMPILER PETSc cxxcompiler)
 set(CMAKE_CXX_COMPILER ${PETSC_CXX_COMPILER})
 
 # Set the project details
-project(ablateLibrary VERSION 0.2.3)
+project(ablateLibrary VERSION 0.2.4)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED PETSc)

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -186,7 +186,7 @@ PetscErrorCode FlowCompleteProblemSetup(FlowData flowData, TS ts){
 
     if(flowData->auxDm){
         ierr = DMCreateDS(flowData->auxDm);CHKERRQ(ierr);
-        ierr = DMCreateGlobalVector(flowData->auxDm, &(flowData->auxField));CHKERRQ(ierr);
+        ierr = DMCreateLocalVector(flowData->auxDm, &(flowData->auxField));CHKERRQ(ierr);
 
         // attach this field as aux vector to the dm
         ierr = PetscObjectCompose((PetscObject) flowData->dm, "A", (PetscObject) flowData->auxField);CHKERRQ(ierr);

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -71,7 +71,7 @@ PetscErrorCode FlowRegisterField(FlowData flow, const char *fieldName, const cha
 
     // create a petsc fe
     PetscFE petscFE;
-    ierr = PetscFECreateDefault(comm, dim, components, simplexGlobal, combinedFieldPrefix, PETSC_DEFAULT, &petscFE);CHKERRQ(ierr);
+    ierr = PetscFECreateDefault(comm, dim, components, simplexGlobal? PETSC_TRUE : PETSC_FALSE, combinedFieldPrefix, PETSC_DEFAULT, &petscFE);CHKERRQ(ierr);
     ierr = PetscObjectSetName((PetscObject)petscFE, fieldName);CHKERRQ(ierr);
 
     //If this is not the first field, copy the quadrature locations
@@ -128,7 +128,7 @@ PetscErrorCode FlowRegisterAuxField(FlowData flow, const char *fieldName, const 
     PetscInt cStart;
     ierr = DMPlexGetHeightStratum(flow->dm, 0, &cStart, NULL);CHKERRQ(ierr);
     ierr = DMPlexGetCellType(flow->dm, cStart, &ct);CHKERRQ(ierr);
-    PetscBool simplex = DMPolytopeTypeGetNumVertices(ct) == DMPolytopeTypeGetDim(ct) + 1 ? PETSC_TRUE : PETSC_FALSE;
+    PetscInt simplex = DMPolytopeTypeGetNumVertices(ct) == DMPolytopeTypeGetDim(ct) + 1 ? PETSC_TRUE : PETSC_FALSE;
     PetscInt simplexGlobal;
 
     // extract the object comm
@@ -144,7 +144,7 @@ PetscErrorCode FlowRegisterAuxField(FlowData flow, const char *fieldName, const 
 
     // create a petsc fe
     PetscFE petscFE;
-    ierr = PetscFECreateDefault(comm, dim, components, simplexGlobal, combinedFieldPrefix, PETSC_DEFAULT, &petscFE);CHKERRQ(ierr);
+    ierr = PetscFECreateDefault(comm, dim, components, simplexGlobal? PETSC_TRUE : PETSC_FALSE, combinedFieldPrefix, PETSC_DEFAULT, &petscFE);CHKERRQ(ierr);
     ierr = PetscObjectSetName((PetscObject)petscFE, fieldName);CHKERRQ(ierr);
 
     //If this is not the first field, copy the quadrature locations

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -9,23 +9,72 @@ PetscErrorCode FlowCreate(FlowData* flow) {
     (*flow)->data = NULL;
     (*flow)->flowField = NULL;
 
+    // setup the basic field names
+    (*flow)->numberFlowFields = 0;
+    PetscErrorCode ierr = PetscMalloc1((*flow)->numberFlowFields, &((*flow)->fieldDescriptors));CHKERRQ(ierr);
+
     PetscFunctionReturn(0);
 }
 
-PetscErrorCode FlowRegisterFields(FlowData flow, PetscInt numberFlowFields, const char* const* flowFields) {
+PetscErrorCode FlowRegisterFields(FlowData flow, const char fieldName[],const char fieldPrefix[], PetscInt components) {
     PetscFunctionBeginUser;
-    flow->numberFlowFields = numberFlowFields;
+    // store the field
+    flow->numberFlowFields++;
+    PetscErrorCode ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberFlowFields,&(flow->fieldDescriptors));CHKERRQ(ierr);
+    flow->fieldDescriptors[flow->numberFlowFields-1].components = components;
+    PetscStrallocpy(fieldName, (char **)&(flow->fieldDescriptors[flow->numberFlowFields-1].fieldName));
+    PetscStrallocpy(fieldPrefix, (char **)&(flow->fieldDescriptors[flow->numberFlowFields-1].fieldPrefix));
 
-    PetscErrorCode ierr = PetscStrNArrayallocpy(numberFlowFields, flowFields, (char***)&(flow->flowFieldNames));CHKERRQ(ierr);
+    // get the dm prefix to help name the fe objects
+    const char *dmPrefix;
+    ierr = DMGetOptionsPrefix(flow->dm, &dmPrefix);CHKERRQ(ierr);
+    char combinedFieldPrefix[128] = "";
+
+    /* Create finite element */
+    ierr = PetscStrlcat(combinedFieldPrefix, dmPrefix, 128);CHKERRQ(ierr);
+    ierr = PetscStrlcat(combinedFieldPrefix, fieldPrefix, 128);CHKERRQ(ierr);
+
+    // determine if it a simplex element and the number of dimensions
+    DMPolytopeType ct;
+    PetscInt cStart;
+    ierr = DMPlexGetHeightStratum(flow->dm, 0, &cStart, NULL);CHKERRQ(ierr);
+    ierr = DMPlexGetCellType(flow->dm, cStart, &ct);CHKERRQ(ierr);
+    PetscBool simplex = DMPolytopeTypeGetNumVertices(ct) == DMPolytopeTypeGetDim(ct) + 1 ? PETSC_TRUE : PETSC_FALSE;
+
+    // Determine the number of dimensions
+    PetscInt dim;
+    ierr = DMGetDimension(flow->dm, &dim);CHKERRQ(ierr);
+
+    // create a petsc fe
+    MPI_Comm comm;
+    PetscFE petscFE;
+    ierr = PetscObjectGetComm((PetscObject)flow->dm, &comm);CHKERRQ(ierr);
+    ierr = PetscFECreateDefault(comm, dim, components, simplex, combinedFieldPrefix, PETSC_DEFAULT, &petscFE);CHKERRQ(ierr);
+    ierr = PetscObjectSetName((PetscObject)petscFE, fieldName);CHKERRQ(ierr);
+
+    //If this is not the first field, copy the quadrature locations
+    if(flow->numberFlowFields > 1){
+        PetscFE referencePetscFE;
+        ierr = DMGetField(flow->dm, 0, NULL, (PetscObject*)&referencePetscFE);CHKERRQ(ierr);
+        ierr = PetscFECopyQuadrature(referencePetscFE, petscFE);CHKERRQ(ierr);
+    }
+
+    // Store the field and destroy copy
+    ierr = DMSetField(flow->dm, flow->numberFlowFields-1, NULL, (PetscObject)petscFE);CHKERRQ(ierr);
+    ierr = PetscFEDestroy(&petscFE);CHKERRQ(ierr);
     PetscFunctionReturn(0);
 }
 
 
 PetscErrorCode FlowDestroy(FlowData* flow) {
     PetscFunctionBeginUser;
-    if ((*flow)->flowFieldNames){
-        PetscErrorCode ierr = PetscStrNArrayDestroy((*flow)->numberFlowFields,(char***)&((*flow)->flowFieldNames));CHKERRQ(ierr);
+    // remove each allocated string and flow field
+    for (PetscInt i =0; i < (*flow)->numberFlowFields; i++){
+        PetscFree((*flow)->fieldDescriptors[i].fieldName);
+        PetscFree((*flow)->fieldDescriptors[i].fieldPrefix);
     }
+    PetscFree((*flow)->fieldDescriptors);
+
     if ((*flow)->flowField){
         PetscErrorCode ierr = VecDestroy(&((*flow)->flowField));CHKERRQ(ierr);
     }

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -31,7 +31,12 @@ PetscErrorCode FlowRegisterField(FlowData flow, const char *fieldName, const cha
     PetscFunctionBeginUser;
     // store the field
     flow->numberFlowFields++;
-    PetscErrorCode ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberFlowFields,&(flow->flowFieldDescriptors));CHKERRQ(ierr);
+    PetscErrorCode ierr;
+    if(flow->flowFieldDescriptors == NULL){
+        ierr = PetscMalloc1(flow->numberFlowFields, &(flow->flowFieldDescriptors));CHKERRQ(ierr);
+    }else{
+        ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberFlowFields,&(flow->flowFieldDescriptors));CHKERRQ(ierr);
+    }
     flow->flowFieldDescriptors[flow->numberFlowFields-1].components = components;
     PetscStrallocpy(fieldName, (char **)&(flow->flowFieldDescriptors[flow->numberFlowFields-1].fieldName));
     PetscStrallocpy(fieldPrefix, (char **)&(flow->flowFieldDescriptors[flow->numberFlowFields-1].fieldPrefix));
@@ -94,7 +99,11 @@ PetscErrorCode FlowRegisterAuxField(FlowData flow, const char *fieldName, const 
 
     // store the field
     flow->numberAuxFields++;
-    ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberAuxFields,&(flow->auxFieldDescriptors));CHKERRQ(ierr);
+    if(flow->auxFieldDescriptors == NULL){
+        ierr = PetscMalloc1(flow->numberAuxFields, &(flow->auxFieldDescriptors));CHKERRQ(ierr);
+    }else{
+        ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberAuxFields,&(flow->auxFieldDescriptors));CHKERRQ(ierr);
+    }
     flow->auxFieldDescriptors[flow->numberAuxFields-1].components = components;
     PetscStrallocpy(fieldName, (char **)&(flow->auxFieldDescriptors[flow->numberAuxFields-1].fieldName));
     PetscStrallocpy(fieldPrefix, (char **)&(flow->auxFieldDescriptors[flow->numberAuxFields-1].fieldPrefix));
@@ -210,7 +219,11 @@ PetscErrorCode FlowRegisterPreStep(FlowData flowData, PetscErrorCode (*updateFun
     PetscErrorCode ierr;
 
     flowData->numberPreStepFunctions++;
-    ierr = PetscRealloc(sizeof(FlowUpdateFunction)*flowData->numberPreStepFunctions,&(flowData->preStepFunctions));CHKERRQ(ierr);
+    if(flowData->preStepFunctions == NULL){
+        ierr = PetscMalloc1(flowData->numberPreStepFunctions, &(flowData->preStepFunctions));CHKERRQ(ierr);
+    }else{
+        ierr = PetscRealloc(sizeof(FlowUpdateFunction)*flowData->numberPreStepFunctions,&(flowData->preStepFunctions));CHKERRQ(ierr);
+    }
     flowData->preStepFunctions[flowData->numberPreStepFunctions-1].updateFunction = updateFunction;
     flowData->preStepFunctions[flowData->numberPreStepFunctions-1].context = context;
     PetscFunctionReturn(0);
@@ -221,7 +234,11 @@ PetscErrorCode FlowRegisterPostStep(FlowData flowData, PetscErrorCode (*updateFu
     PetscErrorCode ierr;
 
     flowData->numberPostStepFunctions++;
-    ierr = PetscRealloc(sizeof(FlowUpdateFunction)*flowData->numberPostStepFunctions,&(flowData->postStepFunctions));CHKERRQ(ierr);
+    if(flowData->postStepFunctions == NULL){
+        ierr = PetscMalloc1(flowData->numberPostStepFunctions, &(flowData->postStepFunctions));CHKERRQ(ierr);
+    }else{
+        ierr = PetscRealloc(sizeof(FlowUpdateFunction)*flowData->numberPostStepFunctions,&(flowData->postStepFunctions));CHKERRQ(ierr);
+    }
     flowData->postStepFunctions[flowData->numberPostStepFunctions-1].updateFunction = updateFunction;
     flowData->postStepFunctions[flowData->numberPostStepFunctions-1].context = context;
     PetscFunctionReturn(0);

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -176,10 +176,11 @@ static PetscErrorCode FlowTSPostStepFunction(TS ts){
 
 PetscErrorCode FlowCompleteProblemSetup(FlowData flowData, TS ts){
     PetscErrorCode ierr;
-    DM dm;
 
     PetscFunctionBeginUser;
-    ierr = TSGetDM(ts, &dm);CHKERRQ(ierr);
+    // Setup the solve with the ts
+    DM dm = flowData->dm;
+    ierr = TSSetDM(ts, flowData->dm);CHKERRQ(ierr);
 
     ierr = DMPlexCreateClosureIndex(dm, NULL);CHKERRQ(ierr);
     ierr = DMCreateGlobalVector(dm, &(flowData->flowField));CHKERRQ(ierr);
@@ -190,6 +191,8 @@ PetscErrorCode FlowCompleteProblemSetup(FlowData flowData, TS ts){
 
         // attach this field as aux vector to the dm
         ierr = PetscObjectCompose((PetscObject) flowData->dm, "A", (PetscObject) flowData->auxField);CHKERRQ(ierr);
+
+        ierr = PetscObjectSetName((PetscObject)flowData->auxField, "auxField");CHKERRQ(ierr);
     }
 
     ierr = DMTSSetBoundaryLocal(dm, DMPlexTSComputeBoundary, NULL);CHKERRQ(ierr);

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -32,7 +32,7 @@ PetscErrorCode FlowRegisterField(FlowData flow, const char *fieldName, const cha
     // store the field
     flow->numberFlowFields++;
     PetscErrorCode ierr;
-    if(flow->flowFieldDescriptors == NULL){
+    if (flow->flowFieldDescriptors == NULL){
         ierr = PetscMalloc1(flow->numberFlowFields, &(flow->flowFieldDescriptors));CHKERRQ(ierr);
     }else{
         ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberFlowFields,&(flow->flowFieldDescriptors));CHKERRQ(ierr);
@@ -99,7 +99,7 @@ PetscErrorCode FlowRegisterAuxField(FlowData flow, const char *fieldName, const 
 
     // store the field
     flow->numberAuxFields++;
-    if(flow->auxFieldDescriptors == NULL){
+    if (flow->auxFieldDescriptors == NULL){
         ierr = PetscMalloc1(flow->numberAuxFields, &(flow->auxFieldDescriptors));CHKERRQ(ierr);
     }else{
         ierr = PetscRealloc(sizeof(FlowFieldDescriptor)*flow->numberAuxFields,&(flow->auxFieldDescriptors));CHKERRQ(ierr);
@@ -219,7 +219,7 @@ PetscErrorCode FlowRegisterPreStep(FlowData flowData, PetscErrorCode (*updateFun
     PetscErrorCode ierr;
 
     flowData->numberPreStepFunctions++;
-    if(flowData->preStepFunctions == NULL){
+    if (flowData->preStepFunctions == NULL){
         ierr = PetscMalloc1(flowData->numberPreStepFunctions, &(flowData->preStepFunctions));CHKERRQ(ierr);
     }else{
         ierr = PetscRealloc(sizeof(FlowUpdateFunction)*flowData->numberPreStepFunctions,&(flowData->preStepFunctions));CHKERRQ(ierr);
@@ -234,7 +234,7 @@ PetscErrorCode FlowRegisterPostStep(FlowData flowData, PetscErrorCode (*updateFu
     PetscErrorCode ierr;
 
     flowData->numberPostStepFunctions++;
-    if(flowData->postStepFunctions == NULL){
+    if (flowData->postStepFunctions == NULL){
         ierr = PetscMalloc1(flowData->numberPostStepFunctions, &(flowData->postStepFunctions));CHKERRQ(ierr);
     }else{
         ierr = PetscRealloc(sizeof(FlowUpdateFunction)*flowData->numberPostStepFunctions,&(flowData->postStepFunctions));CHKERRQ(ierr);

--- a/ablateCore/flow/flow.c
+++ b/ablateCore/flow/flow.c
@@ -64,7 +64,7 @@ PetscErrorCode FlowRegisterField(FlowData flow, const char *fieldName, const cha
     ierr = PetscObjectSetName((PetscObject)petscFE, fieldName);CHKERRQ(ierr);
 
     //If this is not the first field, copy the quadrature locations
-    if(flow->numberFlowFields > 1){
+    if (flow->numberFlowFields > 1){
         PetscFE referencePetscFE;
         ierr = DMGetField(flow->dm, 0, NULL, (PetscObject*)&referencePetscFE);CHKERRQ(ierr);
         ierr = PetscFECopyQuadrature(referencePetscFE, petscFE);CHKERRQ(ierr);
@@ -81,7 +81,7 @@ PetscErrorCode FlowRegisterAuxField(FlowData flow, const char *fieldName, const 
     PetscErrorCode ierr;
 
     // check to see if need to create an aux dm
-    if(flow->auxDm == NULL){
+    if (flow->auxDm == NULL){
         /* MUST call DMGetCoordinateDM() in order to get p4est setup if present */
         DM coordDM;
         ierr = DMGetCoordinateDM(flow->dm, &coordDM);CHKERRQ(ierr);
@@ -127,7 +127,7 @@ PetscErrorCode FlowRegisterAuxField(FlowData flow, const char *fieldName, const 
     ierr = PetscObjectSetName((PetscObject)petscFE, fieldName);CHKERRQ(ierr);
 
     //If this is not the first field, copy the quadrature locations
-    if(flow->numberFlowFields > 1){
+    if (flow->numberFlowFields > 1){
         PetscFE referencePetscFE;
         ierr = DMGetField(flow->dm, 0, NULL, (PetscObject*)&referencePetscFE);CHKERRQ(ierr);
         ierr = PetscFECopyQuadrature(referencePetscFE, petscFE);CHKERRQ(ierr);
@@ -153,7 +153,7 @@ static PetscErrorCode FlowTSPreStepFunction(TS ts){
     FlowData flowData;
     ierr = DMGetApplicationContext(dm, &flowData);CHKERRQ(ierr);
 
-    for(PetscInt i =0; i < flowData->numberPreStepFunctions; i++){
+    for (PetscInt i =0; i < flowData->numberPreStepFunctions; i++){
         ierr = flowData->preStepFunctions[i].updateFunction(ts, flowData->preStepFunctions[i].context);CHKERRQ(ierr);
     }
 
@@ -167,7 +167,7 @@ static PetscErrorCode FlowTSPostStepFunction(TS ts){
     FlowData flowData;
     ierr = DMGetApplicationContext(dm, &flowData);CHKERRQ(ierr);
 
-    for(PetscInt i =0; i < flowData->numberPostStepFunctions; i++){
+    for (PetscInt i =0; i < flowData->numberPostStepFunctions; i++){
         ierr = flowData->postStepFunctions[i].updateFunction(ts, flowData->postStepFunctions[i].context);CHKERRQ(ierr);
     }
 
@@ -184,7 +184,7 @@ PetscErrorCode FlowCompleteProblemSetup(FlowData flowData, TS ts){
     ierr = DMPlexCreateClosureIndex(dm, NULL);CHKERRQ(ierr);
     ierr = DMCreateGlobalVector(dm, &(flowData->flowField));CHKERRQ(ierr);
 
-    if(flowData->auxDm){
+    if (flowData->auxDm){
         ierr = DMCreateDS(flowData->auxDm);CHKERRQ(ierr);
         ierr = DMCreateLocalVector(flowData->auxDm, &(flowData->auxField));CHKERRQ(ierr);
 

--- a/ablateCore/flow/flow.h
+++ b/ablateCore/flow/flow.h
@@ -12,20 +12,29 @@ typedef struct {
 
 struct _FlowData {
     DM dm;               /* flow domain */
+    DM auxDm;               /* holds non solution vector fields */
+
     Vec flowField;  /* The solution to the flow */
+    Vec auxField;  /* The aux field to the flow */
 
     void* data; /* implementation-specific data */
 
-    /** store the fields on the dm swarm **/
+    /** store the fields on the dm**/
     PetscInt numberFlowFields;
-    FlowFieldDescriptor *fieldDescriptors;
+    FlowFieldDescriptor * flowFieldDescriptors;
+
+    /** store the aux fields **/
+    PetscInt numberAuxFields;
+    FlowFieldDescriptor * auxFieldDescriptors;
 };
 
 typedef struct _FlowData* FlowData;
 
 PETSC_EXTERN PetscErrorCode FlowCreate(FlowData* flow);
-PetscErrorCode FlowRegisterFields(FlowData flow, const char fieldName[],const char fieldPrefix[], PetscInt components);
-
+PetscErrorCode FlowRegisterField(FlowData flow, const char* fieldName, const char* fieldPrefix, PetscInt components);
+PetscErrorCode FlowRegisterAuxField(FlowData flow, const char* fieldName, const char* fieldPrefix, PetscInt components);
+PetscErrorCode FlowCompleteProblemSetup(FlowData flow, TS ts);
+PetscErrorCode FlowFinalizeRegisterFields(FlowData flow);
 PETSC_EXTERN PetscErrorCode FlowDestroy(FlowData* flow);
 
 #endif  // ABLATELIBRARY_FLOW_H

--- a/ablateCore/flow/flow.h
+++ b/ablateCore/flow/flow.h
@@ -9,23 +9,34 @@ typedef struct {
     PetscInt components;
 } FlowFieldDescriptor;
 
+typedef struct {
+    void* context;
+    PetscErrorCode (*updateFunction)(TS ts, void* context);
+} FlowUpdateFunction;
+
 
 struct _FlowData {
-    DM dm;               /* flow domain */
-    DM auxDm;               /* holds non solution vector fields */
+    DM dm;    /* flow domain */
+    DM auxDm; /* holds non solution vector fields */
 
-    Vec flowField;  /* The solution to the flow */
+    Vec flowField; /* The solution to the flow */
     Vec auxField;  /* The aux field to the flow */
 
     void* data; /* implementation-specific data */
 
     /** store the fields on the dm**/
     PetscInt numberFlowFields;
-    FlowFieldDescriptor * flowFieldDescriptors;
+    FlowFieldDescriptor* flowFieldDescriptors;
 
     /** store the aux fields **/
     PetscInt numberAuxFields;
-    FlowFieldDescriptor * auxFieldDescriptors;
+    FlowFieldDescriptor* auxFieldDescriptors;
+
+    /** store a list of preStepFunctions and postStepFunctions **/
+    PetscInt numberPreStepFunctions;
+    FlowUpdateFunction* preStepFunctions;
+    PetscInt numberPostStepFunctions;
+    FlowUpdateFunction* postStepFunctions;
 };
 
 typedef struct _FlowData* FlowData;
@@ -35,6 +46,9 @@ PetscErrorCode FlowRegisterField(FlowData flow, const char* fieldName, const cha
 PetscErrorCode FlowRegisterAuxField(FlowData flow, const char* fieldName, const char* fieldPrefix, PetscInt components);
 PetscErrorCode FlowCompleteProblemSetup(FlowData flow, TS ts);
 PetscErrorCode FlowFinalizeRegisterFields(FlowData flow);
+PETSC_EXTERN PetscErrorCode FlowRegisterPreStep(FlowData flowData, PetscErrorCode (*updateFunction)(TS ts, void* context), void* context);
+PETSC_EXTERN PetscErrorCode FlowRegisterPostStep(FlowData flowData, PetscErrorCode (*updateFunction)(TS ts, void* context), void* context);
+
 PETSC_EXTERN PetscErrorCode FlowDestroy(FlowData* flow);
 
 #endif  // ABLATELIBRARY_FLOW_H

--- a/ablateCore/flow/flow.h
+++ b/ablateCore/flow/flow.h
@@ -3,20 +3,28 @@
 
 #include <petsc.h>
 
+typedef struct {
+    const char* fieldName;
+    const char* fieldPrefix;
+    PetscInt components;
+} FlowFieldDescriptor;
+
+
 struct _FlowData {
     DM dm;               /* flow domain */
     Vec flowField;  /* The solution to the flow */
 
     void* data; /* implementation-specific data */
 
+    /** store the fields on the dm swarm **/
     PetscInt numberFlowFields;
-    const char *const * flowFieldNames;
+    FlowFieldDescriptor *fieldDescriptors;
 };
 
 typedef struct _FlowData* FlowData;
 
 PETSC_EXTERN PetscErrorCode FlowCreate(FlowData* flow);
-PetscErrorCode FlowRegisterFields(FlowData flow, PetscInt numberFlowFields, const char *const *flowFields);
+PetscErrorCode FlowRegisterFields(FlowData flow, const char fieldName[],const char fieldPrefix[], PetscInt components);
 
 PETSC_EXTERN PetscErrorCode FlowDestroy(FlowData* flow);
 

--- a/ablateCore/flow/incompressibleFlow.c
+++ b/ablateCore/flow/incompressibleFlow.c
@@ -237,7 +237,7 @@ PetscErrorCode IncompressibleFlow_CompleteFlowInitialization(DM dm, Vec u) {
 }
 
 /* Make the discrete pressure discretely divergence free */
-static PetscErrorCode removeDiscretePressureNullspaceOnTs(TS ts) {
+static PetscErrorCode removeDiscretePressureNullspaceOnTs(TS ts, void* cts) {
     Vec u;
     PetscErrorCode ierr;
     DM dm;
@@ -257,6 +257,7 @@ PetscErrorCode IncompressibleFlow_SetupDiscretization(FlowData flowData, DM dm) 
     PetscFunctionBeginUser;
     //Store the field data
     flowData->dm = dm;
+    ierr = DMSetApplicationContext(flowData->dm, flowData);CHKERRQ(ierr);
 
     // Determine the number of dimensions
     ierr = DMGetDimension(dm, &dim);CHKERRQ(ierr);
@@ -326,7 +327,7 @@ PetscErrorCode IncompressibleFlow_CompleteProblemSetup(FlowData flowData, TS ts)
 
     ierr = TSGetDM(ts, &dm);CHKERRQ(ierr);
     ierr = DMSetNullSpaceConstructor(dm, PRES, createPressureNullSpace);CHKERRQ(ierr);
-    ierr = TSSetPreStep(ts, removeDiscretePressureNullspaceOnTs);CHKERRQ(ierr);
+    ierr = FlowRegisterPreStep(flowData, removeDiscretePressureNullspaceOnTs, NULL);CHKERRQ(ierr);
     PetscFunctionReturn(0);
 }
 

--- a/ablateCore/flow/incompressibleFlow.c
+++ b/ablateCore/flow/incompressibleFlow.c
@@ -26,8 +26,8 @@ static void vIntegrandTestFunction(PetscInt dim, PetscInt Nf, PetscInt NfAux, co
     }
 
     // Add in any fixed source term
-    if(NfAux > 0){
-        for(d =0; d < dim; ++d){
+    if (NfAux > 0){
+        for (d =0; d < dim; ++d){
             f0[d] += a[aOff[MOM] + d];
         }
     }
@@ -62,7 +62,7 @@ static void wIntegrandTestFunction(PetscInt dim, PetscInt Nf, PetscInt NfAux, co
     }
 
     // Add in any fixed source term
-    if(NfAux > 0){
+    if (NfAux > 0){
         f0[0] += a[aOff[ENERGY]];
     }
 }
@@ -88,7 +88,7 @@ static void qIntegrandTestFunction(PetscInt dim, PetscInt Nf, PetscInt NfAux, co
     }
 
     // Add in any fixed source term
-    if(NfAux > 0){
+    if (NfAux > 0){
         f0[0] += a[aOff[MASS]];
     }
 }

--- a/ablateCore/flow/incompressibleFlow.c
+++ b/ablateCore/flow/incompressibleFlow.c
@@ -261,52 +261,13 @@ PetscErrorCode IncompressibleFlow_SetupDiscretization(FlowData flowData, DM dm) 
     //Store the field data
     flowData->dm = dm;
 
-    // determine if it a simplex element and the number of dimensions
-    DMPolytopeType ct;
-    ierr = DMPlexGetHeightStratum(dm, 0, &cStart, NULL);CHKERRQ(ierr);
-    ierr = DMPlexGetCellType(dm, cStart, &ct);CHKERRQ(ierr);
-    PetscBool simplex = DMPolytopeTypeGetNumVertices(ct) == DMPolytopeTypeGetDim(ct) + 1 ? PETSC_TRUE : PETSC_FALSE;
-
     // Determine the number of dimensions
     ierr = DMGetDimension(dm, &dim);CHKERRQ(ierr);
 
-    // get the dm prefix to help name the fe objects
-    const char *dmPrefix;
-    ierr = DMGetOptionsPrefix(dm, &dmPrefix);CHKERRQ(ierr);
-    char fieldPrefix[128] = "";
-
-    /* Create finite element */
-    // set the velocity prefix
-    ierr = PetscStrlcat(fieldPrefix, dmPrefix, 128);CHKERRQ(ierr);
-    ierr = PetscStrlcat(fieldPrefix, "vel_", 128);CHKERRQ(ierr);
-
-    ierr = PetscObjectGetComm((PetscObject)dm, &comm);CHKERRQ(ierr);
-    ierr = PetscFECreateDefault(comm, dim, dim, simplex, fieldPrefix, PETSC_DEFAULT, &fe[0]);CHKERRQ(ierr);
-    ierr = PetscObjectSetName((PetscObject)fe[VEL], incompressibleFlowFieldNames[VEL]);CHKERRQ(ierr);
-
-    // pressure
-    ierr = PetscStrncpy(fieldPrefix, dmPrefix, 128);CHKERRQ(ierr);
-    ierr = PetscStrlcat(fieldPrefix, "pres_", 128);CHKERRQ(ierr);
-
-    ierr = PetscFECreateDefault(comm, dim, 1, simplex, fieldPrefix, PETSC_DEFAULT, &fe[1]);CHKERRQ(ierr);
-    ierr = PetscFECopyQuadrature(fe[VEL], fe[PRES]);CHKERRQ(ierr);
-    ierr = PetscObjectSetName((PetscObject)fe[PRES], incompressibleFlowFieldNames[PRES]);CHKERRQ(ierr);
-
-    // temperature
-    ierr = PetscStrncpy(fieldPrefix, dmPrefix, 128);CHKERRQ(ierr);
-    ierr = PetscStrlcat(fieldPrefix, "temp_", 128);CHKERRQ(ierr);
-
-    ierr = PetscFECreateDefault(comm, dim, 1, simplex, fieldPrefix, PETSC_DEFAULT, &fe[2]);CHKERRQ(ierr);
-    ierr = PetscFECopyQuadrature(fe[VEL], fe[TEMP]);CHKERRQ(ierr);
-    ierr = PetscObjectSetName((PetscObject)fe[TEMP], incompressibleFlowFieldNames[TEMP]);CHKERRQ(ierr);
-
-    // register the fields
-    ierr = FlowRegisterFields(flowData, TOTAL_INCOMPRESSIBLE_FLOW_FIELDS, incompressibleFlowFieldNames);CHKERRQ(ierr);
-
-    /* Set discretization and boundary conditions for each mesh */
-    ierr = DMSetField(dm, VEL, NULL, (PetscObject)fe[VEL]);CHKERRQ(ierr);
-    ierr = DMSetField(dm, PRES, NULL, (PetscObject)fe[PRES]);CHKERRQ(ierr);
-    ierr = DMSetField(dm, TEMP, NULL, (PetscObject)fe[TEMP]);CHKERRQ(ierr);
+    // Register each field, this order must match the order in IncompressibleFlowFields enum
+    ierr = FlowRegisterFields(flowData, incompressibleFlowFieldNames[VEL], "vel_",  dim);CHKERRQ(ierr);
+    ierr = FlowRegisterFields(flowData, incompressibleFlowFieldNames[PRES], "pres_",  1);CHKERRQ(ierr);
+    ierr = FlowRegisterFields(flowData, incompressibleFlowFieldNames[TEMP], "temp_",  1);CHKERRQ(ierr);
 
     // Create the discrete systems for the DM based upon the fields added to the DM
     ierr = DMCreateDS(dm);CHKERRQ(ierr);
@@ -315,11 +276,6 @@ PetscErrorCode IncompressibleFlow_SetupDiscretization(FlowData flowData, DM dm) 
         ierr = DMCopyDisc(dm, cdm);CHKERRQ(ierr);
         ierr = DMGetCoarseDM(cdm, &cdm);CHKERRQ(ierr);
     }
-
-    // Clean up the fields
-    ierr = PetscFEDestroy(&fe[VEL]);CHKERRQ(ierr);
-    ierr = PetscFEDestroy(&fe[PRES]);CHKERRQ(ierr);
-    ierr = PetscFEDestroy(&fe[TEMP]);CHKERRQ(ierr);
 
     {
         PetscObject pressure;

--- a/ablateCore/flow/incompressibleFlow.c
+++ b/ablateCore/flow/incompressibleFlow.c
@@ -312,9 +312,9 @@ PetscErrorCode IncompressibleFlow_EnableAuxFields(FlowData flowData) {
     PetscInt dim;
     PetscErrorCode ierr = DMGetDimension(flowData->dm, &dim);CHKERRQ(ierr);
 
-    ierr = FlowRegisterAuxField(flowData, incompressibleSourceFieldNames[MOM] , incompressibleSourceFieldNames[MOM], dim);CHKERRQ(ierr);
-    ierr = FlowRegisterAuxField(flowData, incompressibleSourceFieldNames[MASS] , incompressibleSourceFieldNames[MASS], 1);CHKERRQ(ierr);
-    ierr = FlowRegisterAuxField(flowData, incompressibleSourceFieldNames[ENERGY] , incompressibleSourceFieldNames[ENERGY], 1);CHKERRQ(ierr);
+    ierr = FlowRegisterAuxField(flowData, incompressibleSourceFieldNames[MOM] , "momentum_source_", dim);CHKERRQ(ierr);
+    ierr = FlowRegisterAuxField(flowData, incompressibleSourceFieldNames[MASS] , "mass_source_", 1);CHKERRQ(ierr);
+    ierr = FlowRegisterAuxField(flowData, incompressibleSourceFieldNames[ENERGY] , "energy_source_", 1);CHKERRQ(ierr);
     PetscFunctionReturn(0);
 }
 

--- a/ablateCore/flow/incompressibleFlow.h
+++ b/ablateCore/flow/incompressibleFlow.h
@@ -13,6 +13,8 @@ PETSC_EXTERN const char *incompressibleFlowParametersTypeNames[TOTAL_INCOMPRESSI
 
 typedef enum {VEL, PRES, TEMP, TOTAL_INCOMPRESSIBLE_FLOW_FIELDS} IncompressibleFlowFields;
 
+typedef enum {MOM, MASS, ENERGY, TOTAL_INCOMPRESSIBLE_SOURCE_FIELDS} IncompressibleSourceFields;
+
 typedef struct {
     PetscReal strouhal;
     PetscReal reynolds;
@@ -30,5 +32,6 @@ PETSC_EXTERN PetscErrorCode IncompressibleFlow_SetupDiscretization(FlowData flow
 PETSC_EXTERN PetscErrorCode IncompressibleFlow_StartProblemSetup(FlowData flowData, PetscInt, PetscScalar[]);
 PETSC_EXTERN PetscErrorCode IncompressibleFlow_CompleteProblemSetup(FlowData flowData, TS ts);
 PETSC_EXTERN PetscErrorCode IncompressibleFlow_CompleteFlowInitialization(DM dm, Vec u);
+PETSC_EXTERN PetscErrorCode IncompressibleFlow_EnableAuxFields(FlowData flowData);
 
 #endif

--- a/ablateCore/flow/lowMachFlow.c
+++ b/ablateCore/flow/lowMachFlow.c
@@ -26,16 +26,9 @@ static void qIntegrandTestFunction(PetscInt dim, PetscInt Nf, PetscInt NfAux, co
     }
 
     // Add in any fixed source term
-    if(NfAux > 0){
+    if (NfAux > 0) {
         f0[0] += a[aOff[MASS]];
     }
-//    const PetscReal S = constants[STROUHAL];
-//    const PetscReal Pth = constants[PTH];
-//    const PetscReal x = X[0];
-//    const PetscReal y = X[1];
-//
-//    f0[0] -= -((Pth * S) / PetscPowReal(1 + t + PetscPowReal(x, 2) / 2. + PetscPowReal(y, 2) / 2., 2)) - (Pth * y * (t + 2 * PetscPowReal(x, 3) + 3 * PetscPowReal(x, 2) * y)) / PetscPowReal(1 + t + PetscPowReal(x, 2) / 2. + PetscPowReal(y, 2) / 2., 2) +
-//             (6 * Pth * PetscPowReal(x, 2)) / (1 + t + PetscPowReal(x, 2) / 2. + PetscPowReal(y, 2) / 2.) - (Pth * x * (t + PetscPowReal(x, 3) + PetscPowReal(y, 3))) / PetscPowReal(1 + t + PetscPowReal(x, 2) / 2. + PetscPowReal(y, 2) / 2., 2);
 }
 
 /* \boldsymbol{v} \cdot \rho S \frac{\partial \boldsymbol{u}}{\partial t} + \boldsymbol{v} \cdot \rho \boldsymbol{u} \cdot \nabla \boldsymbol{u} + \frac{\rho \hat{\boldsymbol{z}}}{F^2} \cdot
@@ -64,8 +57,8 @@ static void vIntegrandTestFunction(PetscInt dim, PetscInt Nf, PetscInt NfAux, co
     f0[(PetscInt)constants[GRAVITY_DIRECTION]] += rho / (constants[FROUDE] * constants[FROUDE]);
 
     // Add in any fixed source term
-    if(NfAux > 0) {
-        for(d =0; d < dim; ++d){
+    if (NfAux > 0) {
+        for (d =0; d < dim; ++d){
             f0[d] += a[aOff[MOM] + d];
         }
     }
@@ -127,7 +120,7 @@ static void wIntegrandTestFunction(PetscInt dim, PetscInt Nf, PetscInt NfAux, co
     }
 
     // Add in any fixed source term
-    if(NfAux > 0) {
+    if (NfAux > 0) {
         f0[0] += a[aOff[ENERGY]];
     }
 }

--- a/ablateCore/flow/lowMachFlow.c
+++ b/ablateCore/flow/lowMachFlow.c
@@ -332,7 +332,7 @@ PetscErrorCode LowMachFlow_CompleteFlowInitialization(DM dm, Vec u) {
 }
 
 /* Make the discrete pressure discretely divergence free */
-static PetscErrorCode removeDiscretePressureNullspaceOnTs(TS ts) {
+static PetscErrorCode removeDiscretePressureNullspaceOnTs(TS ts, void* context) {
     Vec u;
     PetscErrorCode ierr;
     DM dm;
@@ -352,6 +352,7 @@ PetscErrorCode LowMachFlow_SetupDiscretization(FlowData flowData, DM dm) {
     PetscFunctionBeginUser;
     //Store the field data
     flowData->dm = dm;
+    ierr = DMSetApplicationContext(flowData->dm, flowData);CHKERRQ(ierr);
 
     // Determine the number of dimensions
     ierr = DMGetDimension(dm, &dim);CHKERRQ(ierr);
@@ -421,7 +422,7 @@ PetscErrorCode LowMachFlow_CompleteProblemSetup(FlowData flowData, TS ts) {
 
     ierr = TSGetDM(ts, &dm);CHKERRQ(ierr);
     ierr = DMSetNullSpaceConstructor(dm, PRES, createPressureNullSpace);CHKERRQ(ierr);
-    ierr = TSSetPreStep(ts, removeDiscretePressureNullspaceOnTs);CHKERRQ(ierr);
+    ierr = FlowRegisterPreStep(flowData, removeDiscretePressureNullspaceOnTs, NULL);CHKERRQ(ierr);
     PetscFunctionReturn(0);
 }
 

--- a/ablateCore/flow/lowMachFlow.c
+++ b/ablateCore/flow/lowMachFlow.c
@@ -407,9 +407,9 @@ PetscErrorCode LowMachFlow_EnableAuxFields(FlowData flowData) {
     PetscInt dim;
     PetscErrorCode ierr = DMGetDimension(flowData->dm, &dim);CHKERRQ(ierr);
 
-    ierr = FlowRegisterAuxField(flowData, lowMachSourceFieldNames[MOM] , lowMachSourceFieldNames[MOM], dim);CHKERRQ(ierr);
-    ierr = FlowRegisterAuxField(flowData, lowMachSourceFieldNames[MASS] , lowMachSourceFieldNames[MASS], 1);CHKERRQ(ierr);
-    ierr = FlowRegisterAuxField(flowData, lowMachSourceFieldNames[ENERGY] , lowMachSourceFieldNames[ENERGY], 1);CHKERRQ(ierr);
+    ierr = FlowRegisterAuxField(flowData, lowMachSourceFieldNames[MOM] , "momentum_source_", dim);CHKERRQ(ierr);
+    ierr = FlowRegisterAuxField(flowData, lowMachSourceFieldNames[MASS] , "mass_source_", 1);CHKERRQ(ierr);
+    ierr = FlowRegisterAuxField(flowData, lowMachSourceFieldNames[ENERGY] , "energy_source_", 1);CHKERRQ(ierr);
     PetscFunctionReturn(0);
 }
 

--- a/ablateCore/flow/lowMachFlow.h
+++ b/ablateCore/flow/lowMachFlow.h
@@ -13,6 +13,8 @@ PETSC_EXTERN const char* lowMachFlowParametersTypeNames[TOTAL_LOW_MACH_FLOW_PARA
 
 typedef enum {VEL, PRES, TEMP, TOTAL_LOW_MACH_FLOW_FIELDS} LowMachFlowFields;
 
+typedef enum {MOM, MASS, ENERGY, TOTAL_LOW_MACH_SOURCE_FIELDS} LowMachSourceFields;
+
 typedef struct {
     PetscReal strouhal;
     PetscReal reynolds;
@@ -36,5 +38,6 @@ PETSC_EXTERN PetscErrorCode LowMachFlow_SetupDiscretization(FlowData flowData, D
 PETSC_EXTERN PetscErrorCode LowMachFlow_StartProblemSetup(FlowData flowData, PetscInt, PetscScalar []);
 PETSC_EXTERN PetscErrorCode LowMachFlow_CompleteProblemSetup(FlowData flowData, TS ts);
 PETSC_EXTERN PetscErrorCode LowMachFlow_CompleteFlowInitialization(DM dm, Vec u);
+PETSC_EXTERN PetscErrorCode LowMachFlow_EnableAuxFields(FlowData flowData);
 
 #endif

--- a/ablateCore/particles/particleTracer.c
+++ b/ablateCore/particles/particleTracer.c
@@ -113,7 +113,7 @@ static PetscErrorCode advectParticles(TS flowTS, void* ctx) {
     // get the updated time step, and reset if it has gone down
     PetscReal dtUpdated;
     ierr = TSGetTimeStep(sts, &dtUpdated);CHKERRQ(ierr);
-    if(dtUpdated < dtInitial){
+    if (dtUpdated < dtInitial){
         ierr = TSSetTimeStep(sts, dtInitial);CHKERRQ(ierr);
     }
 

--- a/ablateCore/particles/particleTracer.c
+++ b/ablateCore/particles/particleTracer.c
@@ -96,8 +96,9 @@ static PetscErrorCode advectParticles(TS flowTS, void* ctx) {
     // Get the position vector
     ierr = DMSwarmCreateGlobalVectorFromField(sdm,DMSwarmPICField_coor, &particlePosition);CHKERRQ(ierr);
 
-    // Set the start time for TSSolve
-    ierr = TSSetTime(sts, particles->timeInitial);CHKERRQ(ierr);
+    // get the particle time step
+    PetscReal dtInitial;
+    ierr = TSGetTimeStep(sts, &dtInitial);CHKERRQ(ierr);
 
     // Set the max end time based upon the flow end time
     ierr = TSGetTime(flowTS, &time);CHKERRQ(ierr);
@@ -108,6 +109,13 @@ static PetscErrorCode advectParticles(TS flowTS, void* ctx) {
     ierr = TSSolve(sts, particlePosition);CHKERRQ(ierr);
     ierr = VecCopy(particles->flowFinal, particles->flowInitial);CHKERRQ(ierr);
     particles->timeInitial = particles->timeFinal;
+
+    // get the updated time step, and reset if it has gone down
+    PetscReal dtUpdated;
+    ierr = TSGetTimeStep(sts, &dtUpdated);CHKERRQ(ierr);
+    if(dtUpdated < dtInitial){
+        ierr = TSSetTimeStep(sts, dtInitial);CHKERRQ(ierr);
+    }
 
     // Return the coord vector
     ierr = DMSwarmDestroyGlobalVectorFromField(sdm,DMSwarmPICField_coor, &particlePosition);CHKERRQ(ierr);
@@ -144,12 +152,15 @@ PetscErrorCode ParticleTracerSetupIntegrator(ParticleData particles, TS particle
     ierr = TSSetRHSFunction(particleTs, NULL, freeStreaming, particles);CHKERRQ(ierr);
     ierr = TSSetMaxSteps(particleTs, 100000000);CHKERRQ(ierr); // set the max ts to a very large number. This can be over written using ts_max_steps options
 
+    // Set the start time for TSSolve
+    ierr = TSSetTime(particleTs, particles->timeInitial);CHKERRQ(ierr);
+
     // link the solution with the flowTS
     ierr = FlowRegisterPostStep(flowData, advectParticles, particleTs);CHKERRQ(ierr);
 
     // Set up the TS
     ierr = TSSetFromOptions(particleTs);CHKERRQ(ierr);
-
+    ierr = TSViewFromOptions(particleTs,NULL, "-ts_view");CHKERRQ(ierr);
     PetscFunctionReturn(0);
 }
 

--- a/ablateCore/particles/particleTracer.h
+++ b/ablateCore/particles/particleTracer.h
@@ -5,6 +5,6 @@
 PETSC_EXTERN const char ParticleTracerVelocity[];
 
 PETSC_EXTERN PetscErrorCode ParticleTracerCreate(ParticleData* particles, PetscInt ndims);
-PETSC_EXTERN PetscErrorCode ParticleTracerSetupIntegrator(ParticleData particles, TS particleTs, TS flowTs);
+PETSC_EXTERN PetscErrorCode ParticleTracerSetupIntegrator(ParticleData particles, TS particleTs, FlowData flowTs);
 PETSC_EXTERN PetscErrorCode ParticleTracerDestroy(ParticleData* particles);
 #endif  // ABLATE_PARTICLETRACER_H

--- a/ablateCore/particles/particles.c
+++ b/ablateCore/particles/particles.c
@@ -82,7 +82,11 @@ PETSC_EXTERN PetscErrorCode ParticleRegisterPetscDatatypeField(ParticleData part
 
     // store the field
     particles->numberFields++;
-    ierr = PetscRealloc(sizeof(ParticleFieldDescriptor)*particles->numberFields,&(particles->fieldDescriptors));CHKERRQ(ierr);
+    if(particles->fieldDescriptors == NULL){
+        ierr = PetscMalloc1(particles->numberFields, &(particles->fieldDescriptors));CHKERRQ(ierr);
+    }else{
+        ierr = PetscRealloc(sizeof(ParticleFieldDescriptor)*particles->numberFields,&(particles->fieldDescriptors));CHKERRQ(ierr);
+    }
     particles->fieldDescriptors[particles->numberFields-1].type = type;
     particles->fieldDescriptors[particles->numberFields-1].components = blocksize;
     PetscStrallocpy(fieldname, (char **)&(particles->fieldDescriptors[particles->numberFields-1].fieldName));

--- a/ablateCore/particles/particles.c
+++ b/ablateCore/particles/particles.c
@@ -52,7 +52,7 @@ PetscErrorCode ParticleInitializeFlow(ParticleData particles, FlowData flowData)
     // Find the velocity field
     PetscBool found;
     for (PetscInt f =0; f < flowData->numberFlowFields; f++){
-        ierr = PetscStrcmp("velocity",flowData->fieldDescriptors[f].fieldName, &found );CHKERRQ(ierr);
+        ierr = PetscStrcmp("velocity",flowData->flowFieldDescriptors[f].fieldName, &found );CHKERRQ(ierr);
         if(found){
             particles->flowVelocityFieldIndex = f;
             break;

--- a/ablateCore/particles/particles.c
+++ b/ablateCore/particles/particles.c
@@ -52,8 +52,8 @@ PetscErrorCode ParticleInitializeFlow(ParticleData particles, FlowData flowData)
     // Find the velocity field
     PetscBool found;
     for (PetscInt f =0; f < flowData->numberFlowFields; f++){
-        ierr = PetscStrcmp("velocity",flowData->flowFieldDescriptors[f].fieldName, &found );CHKERRQ(ierr);
-        if(found){
+        ierr = PetscStrcmp("velocity",flowData->flowFieldDescriptors[f].fieldName, &found);CHKERRQ(ierr);
+        if (found){
             particles->flowVelocityFieldIndex = f;
             break;
         }

--- a/ablateCore/particles/particles.c
+++ b/ablateCore/particles/particles.c
@@ -82,7 +82,7 @@ PETSC_EXTERN PetscErrorCode ParticleRegisterPetscDatatypeField(ParticleData part
 
     // store the field
     particles->numberFields++;
-    if(particles->fieldDescriptors == NULL){
+    if (particles->fieldDescriptors == NULL){
         ierr = PetscMalloc1(particles->numberFields, &(particles->fieldDescriptors));CHKERRQ(ierr);
     }else{
         ierr = PetscRealloc(sizeof(ParticleFieldDescriptor)*particles->numberFields,&(particles->fieldDescriptors));CHKERRQ(ierr);

--- a/ablateCore/particles/particles.c
+++ b/ablateCore/particles/particles.c
@@ -51,7 +51,13 @@ PetscErrorCode ParticleInitializeFlow(ParticleData particles, FlowData flowData)
 
     // Find the velocity field
     PetscBool found;
-    ierr = PetscEListFind(flowData->numberFlowFields,flowData->flowFieldNames, "velocity",&(particles->flowVelocityFieldIndex),&found);CHKERRQ(ierr);
+    for (PetscInt f =0; f < flowData->numberFlowFields; f++){
+        ierr = PetscStrcmp("velocity",flowData->fieldDescriptors[f].fieldName, &found );CHKERRQ(ierr);
+        if(found){
+            particles->flowVelocityFieldIndex = f;
+            break;
+        }
+    }
     if (!found){
         // get the particle data comm
         MPI_Comm comm;

--- a/ablateLibrary/CMakeLists.txt
+++ b/ablateLibrary/CMakeLists.txt
@@ -30,7 +30,7 @@ set(DISABLE_PETSCXDMFGENERATOR_TESTS ON CACHE BOOL "" FORCE)
 FetchContent_Declare(
         petscXdmfGenerator
         GIT_REPOSITORY https://github.com/UBCHREST/petscXdmfGenerator.git
-        GIT_TAG v0.0.3
+        GIT_TAG v0.0.4
 )
 FetchContent_MakeAvailable(petscXdmfGenerator)
 

--- a/ablateLibrary/flow/flow.cpp
+++ b/ablateLibrary/flow/flow.cpp
@@ -1,7 +1,6 @@
 #include "flow.hpp"
 #include "../utilities/petscError.hpp"
 #include "../utilities/petscOptions.hpp"
-#include "utilities/petscError.hpp"
 
 ablate::flow::Flow::Flow(std::shared_ptr<mesh::Mesh> mesh, std::string name, std::map<std::string, std::string> arguments, std::vector<std::shared_ptr<FlowFieldSolution>> initialization,
                          std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions)
@@ -16,8 +15,8 @@ ablate::flow::Flow::Flow(std::shared_ptr<mesh::Mesh> mesh, std::string name, std
 ablate::flow::Flow::~Flow() { FlowDestroy(&flowData) >> checkError; }
 
 std::optional<int> ablate::flow::Flow::GetFieldId(const std::string& fieldName) {
-    for(auto f = 0; f < flowData->numberFlowFields; f++){
-        if(flowData->flowFieldDescriptors[f].fieldName == fieldName){
+    for (auto f = 0; f < flowData->numberFlowFields; f++) {
+        if (flowData->flowFieldDescriptors[f].fieldName == fieldName) {
             return f;
         }
     }

--- a/ablateLibrary/flow/flow.cpp
+++ b/ablateLibrary/flow/flow.cpp
@@ -3,8 +3,8 @@
 #include "../utilities/petscOptions.hpp"
 
 ablate::flow::Flow::Flow(std::shared_ptr<mesh::Mesh> mesh, std::string name, std::map<std::string, std::string> arguments, std::vector<std::shared_ptr<FlowFieldSolution>> initialization,
-                         std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions)
-    : mesh(mesh), name(name), initialization(initialization), boundaryConditions(boundaryConditions) {
+                         std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions, std::vector<std::shared_ptr<FlowFieldSolution>> auxiliaryFields)
+    : mesh(mesh), name(name), initialization(initialization), boundaryConditions(boundaryConditions), auxiliaryFields(auxiliaryFields) {
     // append any prefix values
     utilities::PetscOptions::Set(name, arguments);
 
@@ -21,4 +21,112 @@ std::optional<int> ablate::flow::Flow::GetFieldId(const std::string& fieldName) 
         }
     }
     return {};
+}
+
+std::optional<int> ablate::flow::Flow::GetAuxFieldId(const std::string& fieldName) {
+    for (auto f = 0; f < flowData->numberAuxFields; f++) {
+        if (flowData->auxFieldDescriptors[f].fieldName == fieldName) {
+            return f;
+        }
+    }
+    return {};
+}
+
+void ablate::flow::Flow::CompleteInitialization() {
+    // Apply any boundary conditions
+    PetscDS prob;
+    DMGetDS(mesh->GetDomain(), &prob) >> checkError;
+
+    // add each boundary condition
+    for (auto boundary : boundaryConditions) {
+        PetscInt id = boundary->GetLabelId();
+        auto fieldId = GetFieldId(boundary->GetFieldName());
+        if (!fieldId) {
+            throw std::invalid_argument("unknown field for boundary: " + boundary->GetFieldName());
+        }
+
+        PetscDSAddBoundary(prob,
+                           DM_BC_ESSENTIAL,
+                           boundary->GetBoundaryName().c_str(),
+                           boundary->GetLabelName().c_str(),
+                           fieldId.value(),
+                           0,
+                           NULL,
+                           (void (*)(void))boundary->GetBoundaryFunction(),
+                           (void (*)(void))boundary->GetBoundaryTimeDerivativeFunction(),
+                           1,
+                           &id,
+                           boundary->GetContext()) >>
+            checkError;
+    }
+
+    // Set the exact solution
+    for (auto exact : initialization) {
+        auto fieldId = GetFieldId(exact->GetName());
+        if (!fieldId) {
+            throw std::invalid_argument("unknown field for initialization: " + exact->GetName());
+        }
+
+        PetscDSSetExactSolution(prob, fieldId.value(), exact->GetSolutionField().GetPetscFunction(), exact->GetSolutionField().GetContext()) >> checkError;
+        PetscDSSetExactSolutionTimeDerivative(prob, fieldId.value(), exact->GetTimeDerivative().GetPetscFunction(), exact->GetTimeDerivative().GetContext()) >> checkError;
+    }
+
+    // check to see if
+    if (flowData->numberAuxFields > 0 && !auxiliaryFields.empty()) {
+        PetscInt numberAuxFields;
+        DMGetNumFields(flowData->auxDm, &numberAuxFields) >> checkError;
+
+        // size up the update and context functions
+        auxiliaryFieldContexts.resize(numberAuxFields, NULL);
+        auxiliaryFieldFunctions.resize(numberAuxFields, NULL);
+
+        // for each given aux field
+        for (auto auxFieldDescription : auxiliaryFields) {
+            auto fieldId = GetAuxFieldId(auxFieldDescription->GetName());
+            if (!fieldId) {
+                throw std::invalid_argument("unknown field for aux field: " + auxFieldDescription->GetName());
+            }
+
+            auxiliaryFieldContexts[fieldId.value()] = auxFieldDescription->GetSolutionField().GetContext();
+            auxiliaryFieldFunctions[fieldId.value()] = auxFieldDescription->GetSolutionField().GetPetscFunction();
+        }
+
+        FlowRegisterPreStep(flowData, UpdateAuxiliaryFields, this);
+    }
+}
+
+PetscErrorCode ablate::flow::Flow::UpdateAuxiliaryFields(TS ts, void* ctx) {
+    PetscFunctionBegin;
+    PetscErrorCode ierr;
+    auto flow = (Flow*)ctx;
+
+    // get the time at the end of the time step
+    PetscReal time = 0;
+    PetscReal dt = 0;
+
+    ierr = TSGetTime(ts, &time);
+    CHKERRQ(ierr);
+    if (time > 0) {
+        ierr = TSGetTimeStep(ts, &dt);
+        CHKERRQ(ierr);
+    }
+    // Update the source terms
+    ierr = DMProjectFunctionLocal(flow->GetFlowData()->auxDm, time + dt, &(flow->auxiliaryFieldFunctions[0]), &(flow->auxiliaryFieldContexts[0]), INSERT_ALL_VALUES, flow->GetFlowData()->auxField);
+    CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+}
+
+void ablate::flow::Flow::SetupSolve(TS& timeStepper) {
+    // Initialize the flow field
+    DMComputeExactSolution(mesh->GetDomain(), 0, flowData->flowField, NULL) >> checkError;
+
+    // Initialize the aux variables
+    if (flowData->numberAuxFields > 0) {
+        UpdateAuxiliaryFields(timeStepper, this) >> checkError;
+    }
+
+    // Re Name the flow field
+    PetscObjectSetName((PetscObject)(flowData->flowField), this->name.c_str()) >> checkError;
+    VecSetOptionsPrefix(flowData->flowField, "num_sol_") >> checkError;
 }

--- a/ablateLibrary/flow/flow.cpp
+++ b/ablateLibrary/flow/flow.cpp
@@ -16,14 +16,10 @@ ablate::flow::Flow::Flow(std::shared_ptr<mesh::Mesh> mesh, std::string name, std
 ablate::flow::Flow::~Flow() { FlowDestroy(&flowData) >> checkError; }
 
 std::optional<int> ablate::flow::Flow::GetFieldId(const std::string& fieldName) {
-    PetscBool found;
-    PetscInt index;
-
-    PetscEListFind(flowData->numberFlowFields, flowData->flowFieldNames, fieldName.c_str(), &index, &found) >> checkError;
-
-    if (found) {
-        return index;
-    } else {
-        return {};
+    for(auto f = 0; f < flowData->numberFlowFields; f++){
+        if(flowData->fieldDescriptors[f].fieldName == fieldName){
+            return f;
+        }
     }
+    return {};
 }

--- a/ablateLibrary/flow/flow.cpp
+++ b/ablateLibrary/flow/flow.cpp
@@ -17,7 +17,7 @@ ablate::flow::Flow::~Flow() { FlowDestroy(&flowData) >> checkError; }
 
 std::optional<int> ablate::flow::Flow::GetFieldId(const std::string& fieldName) {
     for(auto f = 0; f < flowData->numberFlowFields; f++){
-        if(flowData->fieldDescriptors[f].fieldName == fieldName){
+        if(flowData->flowFieldDescriptors[f].fieldName == fieldName){
             return f;
         }
     }

--- a/ablateLibrary/flow/flow.hpp
+++ b/ablateLibrary/flow/flow.hpp
@@ -19,13 +19,24 @@ class Flow : public solve::Solvable {
     const std::string name;
     const std::vector<std::shared_ptr<FlowFieldSolution>> initialization;
     const std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions;
+    const std::vector<std::shared_ptr<FlowFieldSolution>> auxiliaryFields;
 
     // Store the flow data
     FlowData flowData;
 
     Flow(std::shared_ptr<mesh::Mesh> mesh, std::string name, std::map<std::string, std::string> arguments, std::vector<std::shared_ptr<FlowFieldSolution>> initialization,
-         std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions);
+         std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions, std::vector<std::shared_ptr<FlowFieldSolution>> auxiliaryFields);
     virtual ~Flow();
+
+    /**
+     * Method should be call at the end of each constructor to setup boundary conditions and aux field
+     */
+    void CompleteInitialization();
+
+   private:
+    std::vector<mathFunctions::PetscFunction> auxiliaryFieldFunctions;
+    std::vector<void*> auxiliaryFieldContexts;
+    static PetscErrorCode UpdateAuxiliaryFields(TS ts, void* ctx);
 
    public:
     FlowData GetFlowData() { return flowData; }
@@ -34,11 +45,13 @@ class Flow : public solve::Solvable {
 
     const std::string& GetName() const { return name; }
 
-    virtual void SetupSolve(TS& timeStepper) override = 0;
+    virtual void SetupSolve(TS& timeStepper) override;
 
     Vec GetSolutionVector() override { return flowData->flowField; }
 
     std::optional<int> GetFieldId(const std::string& fieldName);
+
+    std::optional<int> GetAuxFieldId(const std::string& fieldName);
 };
 }  // namespace ablate::flow
 

--- a/ablateLibrary/flow/flowFieldSolution.cpp
+++ b/ablateLibrary/flow/flowFieldSolution.cpp
@@ -6,4 +6,4 @@ ablate::flow::FlowFieldSolution::FlowFieldSolution(std::string fieldName, std::s
 
 REGISTERDEFAULT(ablate::flow::FlowFieldSolution, ablate::flow::FlowFieldSolution, "a field description that can be used for initialization or exact solution ",
                 ARG(std::string, "fieldName", "the field name"), ARG(mathFunctions::MathFunction, "solutionField", "the math function used to describe the field"),
-                ARG(mathFunctions::MathFunction, "timeDerivative", "the math function used to describe the field time derivative"));
+                OPT(mathFunctions::MathFunction, "timeDerivative", "the math function used to describe the field time derivative"));

--- a/ablateLibrary/flow/incompressibleFlow.hpp
+++ b/ablateLibrary/flow/incompressibleFlow.hpp
@@ -11,7 +11,8 @@ namespace ablate::flow {
 class IncompressibleFlow : public Flow {
    public:
     IncompressibleFlow(std::string name, std::shared_ptr<mesh::Mesh> mesh, std::map<std::string, std::string> arguments, std::shared_ptr<parameters::Parameters> parameters,
-                       std::vector<std::shared_ptr<FlowFieldSolution>> initialization, std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions);
+                       std::vector<std::shared_ptr<FlowFieldSolution>> initialization, std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions,
+                       std::vector<std::shared_ptr<FlowFieldSolution>> auxiliaryFields);
 
     void SetupSolve(TS& timeStepper) override;
 };

--- a/ablateLibrary/flow/lowMachFlow.cpp
+++ b/ablateLibrary/flow/lowMachFlow.cpp
@@ -4,8 +4,9 @@
 #include "utilities/petscError.hpp"
 
 ablate::flow::LowMachFlow::LowMachFlow(std::string name, std::shared_ptr<mesh::Mesh> mesh, std::map<std::string, std::string> arguments, std::shared_ptr<parameters::Parameters> parameters,
-                                       std::vector<std::shared_ptr<FlowFieldSolution>> initialization, std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions)
-    : Flow(mesh, name, arguments, initialization, boundaryConditions) {
+                                       std::vector<std::shared_ptr<FlowFieldSolution>> initialization, std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions,
+                                       std::vector<std::shared_ptr<FlowFieldSolution>> auxiliaryFields)
+    : Flow(mesh, name, arguments, initialization, boundaryConditions, auxiliaryFields) {
     // Setup the problem
     LowMachFlow_SetupDiscretization(flowData, mesh->GetDomain()) >> checkError;
 
@@ -16,61 +17,24 @@ ablate::flow::LowMachFlow::LowMachFlow(std::string name, std::shared_ptr<mesh::M
     // Start the problem setup
     LowMachFlow_StartProblemSetup(flowData, TOTAL_LOW_MACH_FLOW_PARAMETERS, constants) >> checkError;
 
-    // Apply any boundary condition
     PetscDS prob;
     DMGetDS(mesh->GetDomain(), &prob) >> checkError;
-
-    // add each boundary condition
-    for (auto boundary : boundaryConditions) {
-        PetscInt id = boundary->GetLabelId();
-        auto fieldId = GetFieldId(boundary->GetFieldName());
-        if (!fieldId) {
-            throw std::invalid_argument("unknown field for boundary: " + boundary->GetFieldName());
-        }
-
-        PetscDSAddBoundary(prob,
-                           DM_BC_ESSENTIAL,
-                           boundary->GetBoundaryName().c_str(),
-                           boundary->GetLabelName().c_str(),
-                           fieldId.value(),
-                           0,
-                           NULL,
-                           (void (*)(void))boundary->GetBoundaryFunction(),
-                           (void (*)(void))boundary->GetBoundaryTimeDerivativeFunction(),
-                           1,
-                           &id,
-                           boundary->GetContext()) >>
-            checkError;
+    if (!auxiliaryFields.empty()) {
+        LowMachFlow_EnableAuxFields(flowData);
     }
 
-    // Set the exact solution
-    for (auto exact : initialization) {
-        auto fieldId = GetFieldId(exact->GetName());
-        if (!fieldId) {
-            throw std::invalid_argument("unknown field for initialization: " + exact->GetName());
-        }
-
-        PetscDSSetExactSolution(prob, fieldId.value(), exact->GetSolutionField().GetPetscFunction(), exact->GetSolutionField().GetContext()) >> checkError;
-        PetscDSSetExactSolutionTimeDerivative(prob, fieldId.value(), exact->GetTimeDerivative().GetPetscFunction(), exact->GetTimeDerivative().GetContext()) >> checkError;
-    }
+    // Apply any boundary condition
+    CompleteInitialization();
 }
 
 void ablate::flow::LowMachFlow::SetupSolve(TS &ts) {
-    // Setup the solve with the ts
-    TSSetDM(ts, mesh->GetDomain()) >> checkError;
-
     // finish setup and assign flow field
     LowMachFlow_CompleteProblemSetup(flowData, ts);
-
-    // Name the flow field
-    PetscObjectSetName((PetscObject)(flowData->flowField), "Low Mach Numerical Solution") >> checkError;
-    VecSetOptionsPrefix(flowData->flowField, "num_sol_") >> checkError;
-
-    // set the dm on the ts
-    TSSetDM(ts, mesh->GetDomain()) >> checkError;
+    ablate::flow::Flow::SetupSolve(ts);
 }
 
 REGISTER(ablate::flow::Flow, ablate::flow::LowMachFlow, "low mach flow", ARG(std::string, "name", "the name of the flow field"), ARG(ablate::mesh::Mesh, "mesh", "the mesh"),
          ARG(std::map<std::string TMP_COMMA std::string>, "arguments", "arguments to be passed to petsc"), ARG(ablate::parameters::Parameters, "parameters", "incompressible flow parameters"),
          ARG(std::vector<flow::FlowFieldSolution>, "initialization", "the exact solution used to initialize the flow field"),
-         ARG(std::vector<flow::BoundaryCondition>, "boundaryConditions", "the boundary conditions for the flow field"));
+         ARG(std::vector<flow::BoundaryCondition>, "boundaryConditions", "the boundary conditions for the flow field"),
+         OPT(std::vector<flow::FlowFieldSolution>, "auxFields", "enables and sets the update functions for the auxFields"));

--- a/ablateLibrary/flow/lowMachFlow.hpp
+++ b/ablateLibrary/flow/lowMachFlow.hpp
@@ -11,7 +11,8 @@ namespace ablate::flow {
 class LowMachFlow : public Flow {
    public:
     LowMachFlow(std::string name, std::shared_ptr<mesh::Mesh> mesh, std::map<std::string, std::string> arguments, std::shared_ptr<parameters::Parameters> parameters,
-                std::vector<std::shared_ptr<FlowFieldSolution>> initialization, std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions);
+                std::vector<std::shared_ptr<FlowFieldSolution>> initialization, std::vector<std::shared_ptr<BoundaryCondition>> boundaryConditions,
+                std::vector<std::shared_ptr<FlowFieldSolution>> auxiliaryFields);
 
     void SetupSolve(TS& timeStepper) override;
 };

--- a/ablateLibrary/mathFunctions/parsedFunction.cpp
+++ b/ablateLibrary/mathFunctions/parsedFunction.cpp
@@ -106,7 +106,7 @@ PetscErrorCode ablate::mathFunctions::ParsedFunction::ParsedPetscFunction(PetscI
             u[i] = rawResult[i];
         }
 
-    } catch (std::exception exception) {
+    } catch (std::exception& exception) {
         SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
     }
     PetscFunctionReturn(0);

--- a/ablateLibrary/monitors/flow/CMakeLists.txt
+++ b/ablateLibrary/monitors/flow/CMakeLists.txt
@@ -3,4 +3,6 @@ target_sources(ablateLibrary
         flowMonitor.hpp
         hdf5OutputFlow.hpp
         hdf5OutputFlow.cpp
+        convergenceCheck.hpp
+        convergenceCheck.cpp
         )

--- a/ablateLibrary/monitors/flow/convergenceCheck.cpp
+++ b/ablateLibrary/monitors/flow/convergenceCheck.cpp
@@ -1,0 +1,59 @@
+#include "convergenceCheck.hpp"
+#include "parser/registrar.hpp"
+
+void ablate::monitors::flow::ConvergenceCheck::Register(std::shared_ptr<ablate::flow::Flow> flow) { this->flow = flow; }
+
+ablate::monitors::flow::ConvergenceCheck::ConvergenceCheck(int interval) : interval(interval) {}
+PetscErrorCode ablate::monitors::flow::ConvergenceCheck::CheckConvergence(TS ts, PetscInt steps, PetscReal time, Vec u, void *mctx) {
+    PetscFunctionBeginUser;
+
+    PetscErrorCode ierr;
+
+    // Get the monitor
+    auto monitor = (ablate::monitors::flow::ConvergenceCheck *)mctx;
+
+    // check to make sure that dmts_check has been set for the options
+    PetscOptions options;
+    const char *prefix;
+    ierr = PetscObjectGetOptions((PetscObject)ts, &options);
+    CHKERRQ(ierr);
+    ierr = TSGetOptionsPrefix(ts, &prefix);
+    CHKERRQ(ierr);
+
+    PetscBool dmtsCheckEnabled;
+    PetscOptionsHasName(options, prefix, "-dmts_check", &dmtsCheckEnabled);
+    CHKERRQ(ierr);
+    if (!dmtsCheckEnabled) {
+        PetscOptionsPrefixPush(options, prefix);
+        CHKERRQ(ierr);
+        PetscOptionsSetValue(options, "-dmts_check", NULL);
+        CHKERRQ(ierr);
+        PetscOptionsPrefixPop(options);
+        CHKERRQ(ierr);
+    }
+
+    // check to see if check convergence;
+    bool check = steps == 0;
+    if (!check && monitor->interval > 1) {
+        check = steps % monitor->interval == 0;
+    }
+
+    if (check) {
+        MPI_Comm comm;
+        PetscObjectGetComm((PetscObject)ts, &comm);
+        CHKERRQ(ierr);
+        ierr = PetscPrintf(comm, "////////////////////////\n");
+        CHKERRQ(ierr);
+        ierr = PetscPrintf(comm, "%s Convergence at t:%f n:%d\n", monitor->flow->GetName().c_str(), time, steps);
+        CHKERRQ(ierr);
+        ierr = DMTSCheckFromOptions(ts, u);
+        CHKERRQ(ierr);
+        ierr = PetscPrintf(comm, "////////////////////////\n");
+        CHKERRQ(ierr);
+    }
+
+    PetscFunctionReturn(0);
+}
+
+REGISTER(ablate::monitors::flow::FlowMonitor, ablate::monitors::flow::ConvergenceCheck, "checks the convergence of the dm/ts system",
+         ARG(int, "interval", "the time stepping interval for convergence checking where 0 results in checking the first timestep only"));

--- a/ablateLibrary/monitors/flow/convergenceCheck.hpp
+++ b/ablateLibrary/monitors/flow/convergenceCheck.hpp
@@ -1,0 +1,23 @@
+#ifndef ABLATELIBRARY_CONVERGENCECHECK_HPP
+#define ABLATELIBRARY_CONVERGENCECHECK_HPP
+#include "flowMonitor.hpp"
+
+namespace ablate::monitors::flow {
+class ConvergenceCheck : public FlowMonitor {
+   public:
+    virtual ~ConvergenceCheck() = default;
+    explicit ConvergenceCheck(int interval);
+
+    PetscMonitorFunction GetPetscFunction() override { return CheckConvergence; }
+
+   private:
+    const int interval;  // dictates how often the check is run where 0 is only the first and last step
+    std::shared_ptr<ablate::flow::Flow> flow;
+
+    void Register(std::shared_ptr<ablate::flow::Flow>) override;
+
+    static PetscErrorCode CheckConvergence(TS ts, PetscInt steps, PetscReal time, Vec u, void* mctx);
+};
+}  // namespace ablate::monitors::flow
+
+#endif  // ABLATELIBRARY_CONVERGENCECHECK_HPP

--- a/ablateLibrary/monitors/flow/hdf5OutputFlow.cpp
+++ b/ablateLibrary/monitors/flow/hdf5OutputFlow.cpp
@@ -1,7 +1,6 @@
 #include "hdf5OutputFlow.hpp"
 #include <petsc.h>
 #include <petscviewerhdf5.h>
-#include "generators.hpp"
 #include "monitors/runEnvironment.hpp"
 #include "parser/registrar.hpp"
 #include "utilities/petscError.hpp"

--- a/ablateLibrary/monitors/particles/hdf5OutputParticle.cpp
+++ b/ablateLibrary/monitors/particles/hdf5OutputParticle.cpp
@@ -1,7 +1,6 @@
 #include "hdf5OutputParticle.hpp"
 #include <petsc.h>
 #include <petscviewerhdf5.h>
-#include "generators.hpp"
 #include "monitors/runEnvironment.hpp"
 #include "parser/registrar.hpp"
 #include "utilities/petscError.hpp"

--- a/ablateLibrary/parser/argumentIdentifier.hpp
+++ b/ablateLibrary/parser/argumentIdentifier.hpp
@@ -1,17 +1,23 @@
 #ifndef ABLATELIBRARY_ARGUMENTIDENTIFIER_HPP
 #define ABLATELIBRARY_ARGUMENTIDENTIFIER_HPP
+#include <optional>
 #include <string>
+
 #define TMP_COMMA ,
 
 #define ARG(interfaceTypeFullName, inputName, description) \
-    ablate::parser::ArgumentIdentifier<interfaceTypeFullName> { inputName, description }
+    ablate::parser::ArgumentIdentifier<interfaceTypeFullName> { inputName, description, false }
+
+#define OPT(interfaceTypeFullName, inputName, description) \
+    ablate::parser::ArgumentIdentifier<interfaceTypeFullName> { inputName, description, true }
 
 namespace ablate::parser {
 template <typename Interface>
 struct ArgumentIdentifier {
     const std::string inputName;
     const std::string description;
-    bool operator==(const ArgumentIdentifier<Interface>& other) const { return inputName == other.inputName && description == other.description; }
+    const bool optional;
+    bool operator==(const ArgumentIdentifier<Interface>& other) const { return inputName == other.inputName && description == other.description && optional == other.optional; }
 };
 }  // namespace ablate::parser
 

--- a/ablateLibrary/parser/factory.hpp
+++ b/ablateLibrary/parser/factory.hpp
@@ -43,12 +43,20 @@ class Factory {
     /* produce a shared pointer for the specified interface and type */
     template <typename Interface>
     std::shared_ptr<Interface> Get(const ArgumentIdentifier<Interface>& identifier) const {
+        if (identifier.optional && !Contains(identifier.inputName)) {
+            return {};
+        }
+
         auto childFactory = GetFactory(identifier.inputName);
         return ResolveAndCreate<Interface>(childFactory);
     }
 
     template <typename Interface>
     std::vector<std::shared_ptr<Interface>> Get(const ArgumentIdentifier<std::vector<Interface>>& identifier) const {
+        if (identifier.optional && !Contains(identifier.inputName)) {
+            return {};
+        }
+
         auto childFactories = GetFactorySequence(identifier.inputName);
 
         // Build and resolve the list

--- a/ablateLibrary/parser/listing.cpp
+++ b/ablateLibrary/parser/listing.cpp
@@ -21,7 +21,7 @@ std::ostream& ablate::parser::operator<<(std::ostream& os, const ablate::parser:
 }
 
 std::ostream& ablate::parser::operator<<(std::ostream& os, const ablate::parser::Listing::ArgumentEntry& argumentEntry) {
-    os << argumentEntry.name << "(" << utilities::Demangler::Demangle(argumentEntry.interface) << ") - " << argumentEntry.description;
+    os << argumentEntry.name << "(" << utilities::Demangler::Demangle(argumentEntry.interface) << ") - " << (argumentEntry.optional ? "OPTIONAL: " : "") << argumentEntry.description;
 
     return os;
 }

--- a/ablateLibrary/parser/listing.h
+++ b/ablateLibrary/parser/listing.h
@@ -15,6 +15,7 @@ class Listing {
         const std::string name;
         const std::string interface;
         const std::string description;
+        const bool optional;
         bool operator==(const ArgumentEntry& other) const;
     };
     struct ClassEntry {

--- a/ablateLibrary/parser/registrar.hpp
+++ b/ablateLibrary/parser/registrar.hpp
@@ -118,12 +118,12 @@ class Registrar {
         std::map<std::string, TCreateMethod>& methods = GetConstructionMethods();
         if (auto it = methods.find(className); it == methods.end()) {
             // Record the entry
-            Listing::Get().RecordListing(
-                Listing::ClassEntry{.interface = typeid(Interface).name(),
-                                    .className = className,
-                                    .description = description,
-                                    .arguments = std::vector({Listing::ArgumentEntry{.name = args.inputName, .interface = typeid(Args).name(), .description = args.description}...}),
-                                    .defaultConstructor = defaultConstructor});
+            Listing::Get().RecordListing(Listing::ClassEntry{
+                .interface = typeid(Interface).name(),
+                .className = className,
+                .description = description,
+                .arguments = std::vector({Listing::ArgumentEntry{.name = args.inputName, .interface = typeid(Args).name(), .description = args.description, .optional = args.optional}...}),
+                .defaultConstructor = defaultConstructor});
 
             // create method
             methods[className] = [=](std::shared_ptr<Factory> factory) { return std::make_shared<Class>(factory->Get(args)...); };

--- a/ablateLibrary/parser/yamlParser.cpp
+++ b/ablateLibrary/parser/yamlParser.cpp
@@ -11,42 +11,6 @@ ablate::parser::YamlParser::YamlParser(std::string yamlString) : YamlParser(YAML
 
 ablate::parser::YamlParser::YamlParser(std::filesystem::path filePath) : YamlParser(YAML::LoadFile(filePath), "root", "") {}
 
-std::string ablate::parser::YamlParser::Get(const ablate::parser::ArgumentIdentifier<std::string>& identifier) const {
-    auto parameter = yamlConfiguration[identifier.inputName];
-    if (!parameter) {
-        throw std::invalid_argument("unable to find string " + identifier.inputName + " in " + nodePath);
-    }
-    MarkUsage(identifier.inputName);
-    return parameter.as<std::string>();
-}
-
-std::vector<std::string> ablate::parser::YamlParser::Get(const ablate::parser::ArgumentIdentifier<std::vector<std::string>>& identifier) const {
-    auto parameter = yamlConfiguration[identifier.inputName];
-    if (!parameter) {
-        throw std::invalid_argument("unable to find string vector" + identifier.inputName + " in " + nodePath);
-    }
-    MarkUsage(identifier.inputName);
-    return parameter.as<std::vector<std::string>>();
-}
-
-std::map<std::string, std::string> ablate::parser::YamlParser::Get(const ablate::parser::ArgumentIdentifier<std::map<std::string, std::string>>& identifier) const {
-    auto parameter = yamlConfiguration[identifier.inputName];
-    if (!parameter) {
-        throw std::invalid_argument("unable to find string map" + identifier.inputName + " in " + nodePath);
-    }
-    MarkUsage(identifier.inputName);
-    return parameter.as<std::map<std::string, std::string>>();
-}
-
-int ablate::parser::YamlParser::Get(const ablate::parser::ArgumentIdentifier<int>& identifier) const {
-    auto parameter = yamlConfiguration[identifier.inputName];
-    if (!parameter) {
-        throw std::invalid_argument("unable to find int " + identifier.inputName + " in " + nodePath);
-    }
-    MarkUsage(identifier.inputName);
-    return parameter.as<int>();
-}
-
 std::shared_ptr<ablate::parser::Factory> ablate::parser::YamlParser::GetFactory(const std::string& name) const {
     // Check to see if the child factory has already been created
     if (childFactories.count(name) == 0) {

--- a/ablateLibrary/parser/yamlParser.hpp
+++ b/ablateLibrary/parser/yamlParser.hpp
@@ -24,6 +24,20 @@ class YamlParser : public Factory {
 
     inline void MarkUsage(const std::string& key) const { nodeUsages[key]++; }
 
+    template <typename T>
+    inline T GetValueFromYaml(const ArgumentIdentifier<T>& identifier) const {
+        auto parameter = yamlConfiguration[identifier.inputName];
+        if (!parameter) {
+            if (identifier.optional) {
+                return {};
+            } else {
+                throw std::invalid_argument("unable to " + identifier.inputName + " in " + nodePath);
+            }
+        }
+        MarkUsage(identifier.inputName);
+        return parameter.template as<T>();
+    }
+
    public:
     /***
      * Direct creation using a yaml string
@@ -41,15 +55,17 @@ class YamlParser : public Factory {
     const std::string& GetClassType() const override { return type; }
 
     /* return a string*/
-    std::string Get(const ArgumentIdentifier<std::string>& identifier) const override;
+    std::string Get(const ArgumentIdentifier<std::string>& identifier) const override { return GetValueFromYaml<std::string>(identifier); }
 
     /* and a list of strings */
-    std::vector<std::string> Get(const ArgumentIdentifier<std::vector<std::string>>& identifier) const override;
+    std::vector<std::string> Get(const ArgumentIdentifier<std::vector<std::string>>& identifier) const override { return GetValueFromYaml<std::vector<std::string>>(identifier); }
 
-    std::map<std::string, std::string> Get(const ArgumentIdentifier<std::map<std::string, std::string>>& identifier) const override;
+    std::map<std::string, std::string> Get(const ArgumentIdentifier<std::map<std::string, std::string>>& identifier) const override {
+        return GetValueFromYaml<std::map<std::string, std::string>>(identifier);
+    }
 
     /* return an int for the specified identifier*/
-    int Get(const ArgumentIdentifier<int>& identifier) const override;
+    int Get(const ArgumentIdentifier<int>& identifier) const override { return GetValueFromYaml<int>(identifier); }
 
     /* return a factory that serves as the root of the requested item */
     std::shared_ptr<Factory> GetFactory(const std::string& name) const override;

--- a/ablateLibrary/particles/tracer.cpp
+++ b/ablateLibrary/particles/tracer.cpp
@@ -19,7 +19,7 @@ void ablate::particles::Tracer::InitializeFlow(std::shared_ptr<flow::Flow> flow,
     Particles::InitializeFlow(flow, timeStepper);
 
     // call tracer specific setup
-    ParticleTracerSetupIntegrator(particleData, particleTs, timeStepper->GetTS()) >> checkError;
+    ParticleTracerSetupIntegrator(particleData, particleTs, flow->GetFlowData()) >> checkError;
 }
 
 REGISTER(ablate::particles::Particles, ablate::particles::Tracer, "massless particles that advect with the flow", ARG(std::string, "name", "the name of the particle group"),

--- a/ablateLibrary/solve/timeStepper.cpp
+++ b/ablateLibrary/solve/timeStepper.cpp
@@ -84,7 +84,7 @@ void ablate::solve::TimeStepper::Solve(std::shared_ptr<Solvable> solvable) {
 
     TSMonitorSet(ts, MonitorError, NULL, NULL) >> checkError;
 
-    TSSolve(ts, solutionVec);
+    TSSolve(ts, solutionVec) >> checkError;
 }
 void ablate::solve::TimeStepper::AddMonitor(std::shared_ptr<monitors::Monitor> monitor) {
     // store a reference to the monitor

--- a/ablateLibrary/solve/timeStepper.cpp
+++ b/ablateLibrary/solve/timeStepper.cpp
@@ -84,7 +84,8 @@ void ablate::solve::TimeStepper::Solve(std::shared_ptr<Solvable> solvable) {
 
     TSMonitorSet(ts, MonitorError, NULL, NULL) >> checkError;
 
-    // Before solving, run TSPreStep to initialize any fields
+    TSViewFromOptions(ts, NULL, "-view") >> checkError;
+
     TSSolve(ts, solutionVec) >> checkError;
 }
 void ablate::solve::TimeStepper::AddMonitor(std::shared_ptr<monitors::Monitor> monitor) {

--- a/ablateLibrary/solve/timeStepper.cpp
+++ b/ablateLibrary/solve/timeStepper.cpp
@@ -84,7 +84,7 @@ void ablate::solve::TimeStepper::Solve(std::shared_ptr<Solvable> solvable) {
 
     TSMonitorSet(ts, MonitorError, NULL, NULL) >> checkError;
 
-    TSViewFromOptions(ts, NULL, "-view") >> checkError;
+    TSViewFromOptions(ts, NULL, "-ts_view") >> checkError;
 
     TSSolve(ts, solutionVec) >> checkError;
 }

--- a/ablateLibrary/solve/timeStepper.cpp
+++ b/ablateLibrary/solve/timeStepper.cpp
@@ -84,6 +84,7 @@ void ablate::solve::TimeStepper::Solve(std::shared_ptr<Solvable> solvable) {
 
     TSMonitorSet(ts, MonitorError, NULL, NULL) >> checkError;
 
+    // Before solving, run TSPreStep to initialize any fields
     TSSolve(ts, solutionVec) >> checkError;
 }
 void ablate::solve::TimeStepper::AddMonitor(std::shared_ptr<monitors::Monitor> monitor) {

--- a/docs/content/development/Developing-on-CCR.md
+++ b/docs/content/development/Developing-on-CCR.md
@@ -20,10 +20,9 @@ If a newer version of PETSc is required than those pre-built on CCR you will be 
    ```
 1. Load the required modules
    ```bash
-   module load intel-mpi/2020.2 
-   module load gcc/10.2.0 
+   module load hdf5/1.12.0-mpi 
+   module load gcc/10.2.0
    module load cmake/3.17.1
-   module load hdf5/1.12.0
    ```
 1. Inside the petsc folder, configure PETSc and build PETSc
    ```bash
@@ -57,10 +56,9 @@ If a newer version of PETSc is required than those pre-built on CCR you will be 
        ```
    - If loading from custom built PETSc
        ```bash
-       module load intel-mpi/2020.2
+       module load hdf5/1.12.0-mpi 
        module load gcc/10.2.0
        module load cmake/3.17.1
-       module load hdf5/1.12.0
      
        export PETSC_DIR="path/to/petsc/dir"
        export PETSC_ARCH=petsc_arch
@@ -116,14 +114,9 @@ CCR uses SLURMS for scheduling and therefore job scripts specifying the job. Det
  module list
  
  # Uncomment and set paths if built with custom petsc
- #module load intel-mpi/2020.2
- #module load gcc/10.2.0
- #module load cmake/3.17.1
- #module load hdf5/1.12.0
- #
- #export PETSC_DIR="path/to/petsc/dir"
- #export PETSC_DIR=petsc_arch
- #export PKG_CONFIG_PATH=${PETSC_DIR}/${PETSC_ARCH}/lib/pkgconfig
+#module load hdf5/1.12.0-mpi 
+#module load gcc/10.2.0
+#module load cmake/3.17.1
 
  # The initial srun will trigger the SLURM prologue on the compute nodes.
  NPROCS=`srun --nodes=${SLURM_NNODES} bash -c 'hostname' |wc -l`

--- a/docs/content/development/Developing-on-CCR.md
+++ b/docs/content/development/Developing-on-CCR.md
@@ -28,13 +28,15 @@ If a newer version of PETSc is required than those pre-built on CCR you will be 
 1. Inside the petsc folder, configure PETSc and build PETSc
    ```bash
        ./configure  \
-        --with-mpi-dir=/util/academic/intel/20.2/compilers_and_libraries_2020.2.254/linux/mpi/intel64/ \
-        --with-hdf5 --download-ctetgen --download-fftw  \
+        --with-mpi-dir=${I_MPI_ROOT}/intel64/ \
+        --with-hdf5-dir=${HDF5} --download-ctetgen --download-fftw  \
  	    --download-egads --download-metis \
  	    --download-ml --download-mumps --download-netcdf --download-p4est \
  	    --download-parmetis --download-pnetcdf --download-scalapack \
  	    --download-slepc --download-suitesparse --download-superlu_dist \
- 	    --download-triangle --download-zlib --download-libpng
+ 	    --download-triangle --with-zlib --with-libpng
+   
+      #  --with-debugging=0 can be added to build PETSc in release
    
       # Follow the on screen instructions to build and test
    ```
@@ -61,7 +63,7 @@ If a newer version of PETSc is required than those pre-built on CCR you will be 
        module load hdf5/1.12.0
      
        export PETSC_DIR="path/to/petsc/dir"
-       export PETSC_DIR=petsc_arch
+       export PETSC_ARCH=petsc_arch
        export PKG_CONFIG_PATH=${PETSC_DIR}/${PETSC_ARCH}/lib/pkgconfig
 
        ```

--- a/tests/ablateCore/CMakeLists.txt
+++ b/tests/ablateCore/CMakeLists.txt
@@ -3,10 +3,13 @@ target_link_libraries(coreTests PUBLIC gtest gmock ablateCore testingResources m
 
 target_sources(coreTests
         PRIVATE
-        lowMachFlowTests.cpp
+        lowMachFlowDynamicSourceTests.cpp
         incompressibleFlowFunctionSourceTests.cpp
         incompressibleFlowDynamicSourceTests.cpp
         incompressibleFlowParameterTests.cpp
+        lowMachFlowFunctionSourceTests.cpp
+        lowMachFlowDynamicSourceTests.cpp
+        lowMachFlowParameterTests.cpp
         particleTests.cpp
         main.cpp
         )

--- a/tests/ablateCore/CMakeLists.txt
+++ b/tests/ablateCore/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_executable(coreTests "")
-target_link_libraries(coreTests PUBLIC gtest gmock ablateCore testingResources)
+target_link_libraries(coreTests PUBLIC gtest gmock ablateCore testingResources muparser)
 
 target_sources(coreTests
         PRIVATE
         lowMachFlowTests.cpp
         incompressibleFlowTests.cpp
+        incompressibleFlowDynamicSourceTests.cpp
         particleTests.cpp
         main.cpp
         )

--- a/tests/ablateCore/CMakeLists.txt
+++ b/tests/ablateCore/CMakeLists.txt
@@ -4,8 +4,9 @@ target_link_libraries(coreTests PUBLIC gtest gmock ablateCore testingResources m
 target_sources(coreTests
         PRIVATE
         lowMachFlowTests.cpp
-        incompressibleFlowTests.cpp
+        incompressibleFlowFunctionSourceTests.cpp
         incompressibleFlowDynamicSourceTests.cpp
+        incompressibleFlowParameterTests.cpp
         particleTests.cpp
         main.cpp
         )
@@ -24,3 +25,8 @@ add_custom_command(
         $<TARGET_FILE_DIR:coreTests>/outputs
 )
 
+# add testing support specific to ablateCore
+add_subdirectory(support)
+
+# Allow private access to the header files in the directory
+target_include_directories(coreTests PRIVATE ${CMAKE_CURRENT_LIST_DIR})

--- a/tests/ablateCore/incompressibleFlowDynamicSourceTests.cpp
+++ b/tests/ablateCore/incompressibleFlowDynamicSourceTests.cpp
@@ -379,17 +379,17 @@ INSTANTIATE_TEST_SUITE_P(
             .qSource = ".0"},
         (IncompressibleFlowDynamicSourceMMSParameters){
             .mpiTestParameter = {.testName = "incompressible 2d cubic tri_p3_p2_p2",
-                .nproc = 1,
-                .expectedOutputFile = "outputs/incompressible_2d_tri_p3_p2_p2",
-                .arguments = "-dm_plex_separate_marker -dm_refine 0 "
-                             "-vel_petscspace_degree 3 -pres_petscspace_degree 2 -temp_petscspace_degree 2 "
-                             "-dmts_check .001 -ts_max_steps 4 -ts_dt 0.1 "
-                             "-snes_convergence_test correct_pressure "
-                             "-ksp_type fgmres -ksp_gmres_restart 10 -ksp_rtol 1.0e-9 -ksp_error_if_not_converged "
-                             "-pc_type fieldsplit -pc_fieldsplit_0_fields 0,2 -pc_fieldsplit_1_fields 1 -pc_fieldsplit_type schur -pc_fieldsplit_schur_factorization_type full "
-                             "-fieldsplit_0_pc_type lu "
-                             "-fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi "
-                             "-momentum_sourcepetscspace_degree 5 -mass_sourcepetscspace_degree 1 -energy_sourcepetscspace_degree 5"},
+                                 .nproc = 1,
+                                 .expectedOutputFile = "outputs/incompressible_2d_tri_p3_p2_p2",
+                                 .arguments = "-dm_plex_separate_marker -dm_refine 0 "
+                                              "-vel_petscspace_degree 3 -pres_petscspace_degree 2 -temp_petscspace_degree 2 "
+                                              "-dmts_check .001 -ts_max_steps 4 -ts_dt 0.1 "
+                                              "-snes_convergence_test correct_pressure "
+                                              "-ksp_type fgmres -ksp_gmres_restart 10 -ksp_rtol 1.0e-9 -ksp_error_if_not_converged "
+                                              "-pc_type fieldsplit -pc_fieldsplit_0_fields 0,2 -pc_fieldsplit_1_fields 1 -pc_fieldsplit_type schur -pc_fieldsplit_schur_factorization_type full "
+                                              "-fieldsplit_0_pc_type lu "
+                                              "-fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi "
+                                              "-momentum_sourcepetscspace_degree 5 -mass_sourcepetscspace_degree 1 -energy_sourcepetscspace_degree 5"},
             .uExact = "t + x^3 + y^3, t + 2*x^3 - 3*x^2*y, 1.0, 1.0",
             .pExact = "3/2 *x^2 + 3/2*y^2 -1, 0.0",
             .TExact = "t + 1/2*x^2 +1/2*y^2, 1.0",

--- a/tests/ablateCore/incompressibleFlowDynamicSourceTests.cpp
+++ b/tests/ablateCore/incompressibleFlowDynamicSourceTests.cpp
@@ -352,7 +352,7 @@ INSTANTIATE_TEST_SUITE_P(
                                               "-pc_type fieldsplit -pc_fieldsplit_0_fields 0,2 -pc_fieldsplit_1_fields 1 -pc_fieldsplit_type schur -pc_fieldsplit_schur_factorization_type full "
                                               "-fieldsplit_0_pc_type lu "
                                               "-fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi "
-                                              "-momentum_sourcepetscspace_degree 2 -mass_sourcepetscspace_degree 1 -energy_sourcepetscspace_degree 2"},
+                                              "-momentum_source_petscspace_degree 2 -mass_source_petscspace_degree 1 -energy_source_petscspace_degree 2"},
             .uExact = "t + x^2 + y^2, t + 2*x^2 - 2*x*y, 1.0, 1.0",
             .pExact = "x + y -1, 0.0",
             .TExact = "t + x +y, 1.0",
@@ -370,7 +370,7 @@ INSTANTIATE_TEST_SUITE_P(
                                               "-pc_type fieldsplit -pc_fieldsplit_0_fields 0,2 -pc_fieldsplit_1_fields 1 -pc_fieldsplit_type schur -pc_fieldsplit_schur_factorization_type full "
                                               "-fieldsplit_0_pc_type lu "
                                               "-fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi "
-                                              "-momentum_sourcepetscspace_degree 2 -mass_sourcepetscspace_degree 1 -energy_sourcepetscspace_degree 2"},
+                                              "-momentum_source_petscspace_degree 2 -mass_source_petscspace_degree 1 -energy_source_petscspace_degree 2"},
             .uExact = "t + x^2 + y^2, t + 2*x^2 - 2*x*y, 1.0, 1.0",
             .pExact = "x + y -1, 0.0",
             .TExact = "t + x +y, 1.0",
@@ -389,7 +389,7 @@ INSTANTIATE_TEST_SUITE_P(
                                               "-pc_type fieldsplit -pc_fieldsplit_0_fields 0,2 -pc_fieldsplit_1_fields 1 -pc_fieldsplit_type schur -pc_fieldsplit_schur_factorization_type full "
                                               "-fieldsplit_0_pc_type lu "
                                               "-fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi "
-                                              "-momentum_sourcepetscspace_degree 5 -mass_sourcepetscspace_degree 1 -energy_sourcepetscspace_degree 5"},
+                                              "-momentum_source_petscspace_degree 5 -mass_source_petscspace_degree 1 -energy_source_petscspace_degree 5"},
             .uExact = "t + x^3 + y^3, t + 2*x^3 - 3*x^2*y, 1.0, 1.0",
             .pExact = "3/2 *x^2 + 3/2*y^2 -1, 0.0",
             .TExact = "t + 1/2*x^2 +1/2*y^2, 1.0",

--- a/tests/ablateCore/incompressibleFlowDynamicSourceTests.cpp
+++ b/tests/ablateCore/incompressibleFlowDynamicSourceTests.cpp
@@ -1,0 +1,387 @@
+static char help[] =
+    "Time-dependent Low Mach Flow in 2d channels with finite elements.\n\
+We solve the incompressible problem in a rectangular\n\
+domain, using a parallel unstructured mesh (DMPLEX) to discretize it.\n\n\n";
+
+#include <muParser.h>
+#include <petsc.h>
+#include "MpiTestFixture.hpp"
+#include "flow.h"
+#include "gtest/gtest.h"
+#include "incompressibleFlow.h"
+#include "mesh.h"
+
+struct IncompressibleFlowDynamicSourceMMSParameters {
+    testingResources::MpiTestParameter mpiTestParameter;
+    std::string uExact;
+    std::string pExact;
+    std::string TExact;
+    std::string vSource;
+    std::string wSource;
+    std::string qSource;
+
+};
+
+struct ParsedSolutionData {
+    mutable double coordinate[3] = {0, 0, 0};
+    mutable double time = 0.0;
+    mu::Parser parser;
+
+    ParsedSolutionData(std::string formula){
+        // define the x,y,z and t variables
+        parser.DefineVar("x", &coordinate[0]);
+        parser.DefineVar("y", &coordinate[1]);
+        parser.DefineVar("z", &coordinate[2]);
+        parser.DefineVar("t", &time);
+
+        parser.SetExpr(formula);
+    }
+    static PetscErrorCode ApplySolution(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar *u, void *ctx){
+        PetscFunctionBeginUser;
+        try {
+            auto parser = (ParsedSolutionData*)ctx;
+
+            // update the coordinates
+            parser->coordinate[0] = 0;
+            parser->coordinate[1] = 0;
+            parser->coordinate[2] = 0;
+
+            for (auto i = 0; i < std::min(dim, 3); i++) {
+                parser->coordinate[i] = x[i];
+            }
+            parser->time = time;
+
+            // Evaluate
+            int functionSize = 0;
+            auto rawResult = parser->parser.Eval(functionSize);
+
+            // copy over
+            for (auto i = 0; i < Nf; i++) {
+                u[i] = rawResult[i];
+            }
+
+        } catch (std::exception exception) {
+            SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
+        }
+        PetscFunctionReturn(0);
+    }
+
+    static PetscErrorCode ApplySolutionTimeDerivative(PetscInt dim, PetscReal time, const PetscReal *x, PetscInt Nf, PetscScalar *u, void *ctx){
+        PetscFunctionBeginUser;
+        try {
+            auto parser = (ParsedSolutionData*)ctx;
+
+            // update the coordinates
+            parser->coordinate[0] = 0;
+            parser->coordinate[1] = 0;
+            parser->coordinate[2] = 0;
+
+            for (auto i = 0; i < std::min(dim, 3); i++) {
+                parser->coordinate[i] = x[i];
+            }
+            parser->time = time;
+
+            // Evaluate
+            int functionSize = 0;
+            auto rawResult = parser->parser.Eval(functionSize);
+
+            // copy over
+            for (auto i = 0; i < Nf; i++) {
+                u[i] = rawResult[i + Nf];
+            }
+
+        } catch (std::exception exception) {
+            SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
+        }
+        PetscFunctionReturn(0);
+    }
+
+
+};
+
+struct SourceTermUpdater {
+    ParsedSolutionData fieldData[3];
+
+    static PetscErrorCode UpdateSourceTerms(TS ts, void* ctx) {
+        PetscFunctionBegin;
+        auto sourceTermUpdater = (SourceTermUpdater*)ctx;
+
+        DM dm;
+        PetscErrorCode ierr = TSGetDM(ts, &dm);
+        CHKERRQ(ierr);
+        FlowData flowData;
+        ierr = DMGetApplicationContext(dm, &flowData);     CHKERRQ(ierr);
+
+        PetscErrorCode (*funcs[3])(PetscInt, PetscReal, const PetscReal [], PetscInt, PetscScalar *, void *);
+        funcs[0] = ParsedSolutionData::ApplySolution;
+        funcs[1] = ParsedSolutionData::ApplySolution;
+        funcs[2] = ParsedSolutionData::ApplySolution;
+        void          *ctxs[3];
+        ctxs[0] = &sourceTermUpdater->fieldData[0];
+        ctxs[1] = &sourceTermUpdater->fieldData[1];
+        ctxs[2] = &sourceTermUpdater->fieldData[2];
+
+        // get the time at the end of the time step
+        PetscReal time;
+        ierr = TSGetTime(ts, &time);     CHKERRQ(ierr);
+        PetscReal dt;
+        ierr = TSGetTimeStep(ts, &dt);     CHKERRQ(ierr);
+
+        // Update the source terms
+        ierr =  DMProjectFunction(flowData->auxDm, time + dt, funcs,ctxs , INSERT_ALL_VALUES, flowData->auxField);     CHKERRQ(ierr);
+
+        PetscFunctionReturn(0);
+    }
+};
+
+
+class IncompressibleFlowDynamicSourceMMS : public testingResources::MpiTestFixture, public ::testing::WithParamInterface<IncompressibleFlowDynamicSourceMMSParameters> {
+   public:
+    void SetUp() override { SetMpiParameters(GetParam().mpiTestParameter); }
+};
+
+static PetscErrorCode SetInitialConditions(TS ts, Vec u) {
+    DM dm;
+    PetscReal t;
+    PetscErrorCode ierr;
+
+    PetscFunctionBegin;
+    ierr = TSGetDM(ts, &dm);
+    CHKERRQ(ierr);
+    ierr = TSGetTime(ts, &t);
+    CHKERRQ(ierr);
+
+    // This function Tags the u vector as the exact solution.  We need to copy the values to prevent this.
+    Vec e;
+    ierr = VecDuplicate(u, &e);
+    CHKERRQ(ierr);
+    ierr = DMComputeExactSolution(dm, t, e, NULL);
+    CHKERRQ(ierr);
+    ierr = VecCopy(e, u);
+    CHKERRQ(ierr);
+    ierr = VecDestroy(&e);
+    CHKERRQ(ierr);
+
+    // get the flow to apply the completeFlowInitialization method
+    ierr = IncompressibleFlow_CompleteFlowInitialization(dm, u);
+    CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+}
+
+static PetscErrorCode MonitorError(TS ts, PetscInt step, PetscReal crtime, Vec u, void *ctx) {
+    PetscErrorCode (*exactFuncs[3])(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar *u, void *ctx);
+    void *ctxs[3];
+    DM dm;
+    PetscDS ds;
+    PetscReal ferrors[3];
+    PetscInt f;
+    PetscErrorCode ierr;
+
+    PetscFunctionBeginUser;
+    ierr = TSGetDM(ts, &dm);
+    CHKERRQ(ierr);
+    ierr = DMGetDS(dm, &ds);
+    CHKERRQ(ierr);
+
+    ierr = VecViewFromOptions(u, NULL, "-vec_view_monitor");
+    CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+    for (f = 0; f < 3; ++f) {
+        ierr = PetscDSGetExactSolution(ds, f, &exactFuncs[f], &ctxs[f]);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+    }
+    ierr = DMComputeL2FieldDiff(dm, crtime, exactFuncs, ctxs, u, ferrors);
+    CHKERRABORT(PETSC_COMM_WORLD, ierr);
+    ierr = PetscPrintf(PETSC_COMM_WORLD, "Timestep: %04d time = %-8.4g \t L_2 Error: [%2.3g, %2.3g, %2.3g]\n", (int)step, (double)crtime, (double)ferrors[0], (double)ferrors[1], (double)ferrors[2]);
+    CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+
+    PetscFunctionReturn(0);
+}
+
+
+
+TEST_P(IncompressibleFlowDynamicSourceMMS, ShouldConvergeToExactSolution) {
+    StartWithMPI
+        DM dm;                 /* problem definition */
+        TS ts;                 /* timestepper */
+        PetscBag parameterBag; /* constant flow parameters */
+        FlowData flowData;     /* store some of the flow data*/
+        PetscReal t;
+        PetscErrorCode ierr;
+
+        // Get the testing param
+        auto testingParam = GetParam();
+
+        // initialize petsc and mpi
+        PetscInitialize(argc, argv, NULL, help);
+
+        // setup the ts
+        ierr = TSCreate(PETSC_COMM_WORLD, &ts);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = CreateMesh(PETSC_COMM_WORLD, &dm, PETSC_TRUE, 2);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = TSSetDM(ts, dm);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = TSSetExactFinalTime(ts, TS_EXACTFINALTIME_MATCHSTEP);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Setup the flow data
+        ierr = FlowCreate(&flowData);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // setup problem
+        ierr = IncompressibleFlow_SetupDiscretization(flowData, dm);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // get the flow parameters from options
+        IncompressibleFlowParameters *flowParameters;
+        ierr = IncompressibleFlow_ParametersFromPETScOptions(&parameterBag);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = PetscBagGetData(parameterBag, (void **)&flowParameters);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Start the problem setup
+        PetscScalar constants[TOTAL_INCOMPRESSIBLE_FLOW_PARAMETERS];
+        ierr = IncompressibleFlow_PackParameters(flowParameters, constants);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = IncompressibleFlow_StartProblemSetup(flowData, TOTAL_INCOMPRESSIBLE_FLOW_PARAMETERS, constants);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        ParsedSolutionData uExact(testingParam.uExact);
+        ParsedSolutionData pExact(testingParam.pExact);
+        ParsedSolutionData TExact(testingParam.TExact);
+
+        // Override problem with source terms, boundary, and set the exact solution
+        {
+            PetscDS prob;
+            ierr = DMGetDS(dm, &prob);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+            /* Setup Boundary Conditions */
+            PetscInt id;
+            id = 3;
+            ierr = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "top wall velocity", "marker", VEL, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &uExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 1;
+            ierr =
+                PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "bottom wall velocity", "marker", VEL, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &uExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 2;
+            ierr =
+                PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "right wall velocity", "marker", VEL, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &uExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 4;
+            ierr = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "left wall velocity", "marker", VEL, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &uExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 3;
+            ierr = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "top wall temp", "marker", TEMP, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &TExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 1;
+            ierr = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "bottom wall temp", "marker", TEMP, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &TExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 2;
+            ierr = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "right wall temp", "marker", TEMP, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &TExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            id = 4;
+            ierr = PetscDSAddBoundary(prob, DM_BC_ESSENTIAL, "left wall temp", "marker", TEMP, 0, NULL, (void (*)(void))ParsedSolutionData::ApplySolution, (void (*)(void))ParsedSolutionData::ApplySolutionTimeDerivative, 1, &id, &TExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+            // Set the exact solution
+            ierr = PetscDSSetExactSolution(prob, VEL, ParsedSolutionData::ApplySolution, &uExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            ierr = PetscDSSetExactSolution(prob, PRES, ParsedSolutionData::ApplySolution, &pExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            ierr = PetscDSSetExactSolution(prob, TEMP, ParsedSolutionData::ApplySolution, &TExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            ierr = PetscDSSetExactSolutionTimeDerivative(prob, VEL, ParsedSolutionData::ApplySolutionTimeDerivative, &uExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            ierr = PetscDSSetExactSolutionTimeDerivative(prob, PRES, ParsedSolutionData::ApplySolutionTimeDerivative, &pExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+            ierr = PetscDSSetExactSolutionTimeDerivative(prob, TEMP, ParsedSolutionData::ApplySolutionTimeDerivative, &TExact);
+            CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        }
+        // enable aux fields
+        ierr = IncompressibleFlow_EnableAuxFields(flowData);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        ierr = IncompressibleFlow_CompleteProblemSetup(flowData, ts);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Name the flow field
+        ierr = PetscObjectSetName(((PetscObject)flowData->flowField), "Numerical Solution");
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Setup the TS
+        ierr = TSSetFromOptions(ts);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // update the source terms before each time step
+        SourceTermUpdater updater{
+            .fieldData = {ParsedSolutionData(testingParam.vSource), ParsedSolutionData(testingParam.qSource), ParsedSolutionData(testingParam.wSource)}
+        };
+
+        ierr = FlowRegisterPreStep(flowData, SourceTermUpdater::UpdateSourceTerms, &updater);
+        SourceTermUpdater::UpdateSourceTerms(ts, &updater);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Set initial conditions from the exact solution
+        ierr = TSSetComputeInitialCondition(ts, SetInitialConditions);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr); /* Must come after SetFromOptions() */
+        ierr = SetInitialConditions(ts, flowData->flowField);
+
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = TSGetTime(ts, &t);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = DMSetOutputSequenceNumber(dm, 0, t);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = DMTSCheckFromOptions(ts, flowData->flowField);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = TSMonitorSet(ts, MonitorError, NULL, NULL);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        ierr = TSSolve(ts, flowData->flowField);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Compare the actual vs expected values
+        ierr = DMTSCheckFromOptions(ts, flowData->flowField);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        // Cleanup
+        ierr = FlowDestroy(&flowData);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = DMDestroy(&dm);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = TSDestroy(&ts);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = PetscBagDestroy(&parameterBag);
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+        ierr = PetscFinalize();
+        exit(ierr);
+    EndWithMPI
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IncompressibleFlow, IncompressibleFlowDynamicSourceMMS,
+    testing::Values(
+        (IncompressibleFlowDynamicSourceMMSParameters){
+            .mpiTestParameter = {.testName = "incompressible 2d quadratic tri_p2_p1_p1",
+                                 .nproc = 1,
+                                 .expectedOutputFile = "outputs/incompressible_2d_tri_p2_p1_p1",
+                                 .arguments = "-dm_plex_separate_marker -dm_refine 0 "
+                                              "-vel_petscspace_degree 2 -pres_petscspace_degree 1 -temp_petscspace_degree 1 "
+                                              "-dmts_check .001 -ts_max_steps 4 -ts_dt 0.1 "
+                                              "-ksp_type fgmres -ksp_gmres_restart 10 -ksp_rtol 1.0e-9 -ksp_error_if_not_converged "
+                                              "-pc_type fieldsplit -pc_fieldsplit_0_fields 0,2 -pc_fieldsplit_1_fields 1 -pc_fieldsplit_type schur -pc_fieldsplit_schur_factorization_type full "
+                                              "-fieldsplit_0_pc_type lu "
+                                              "-fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_pc_type jacobi"},
+            .uExact = "t + x^2 + y^2, t + 2*x^2 - 2*x*y, 1.0, 1.0",
+            .pExact = "x + y -1, 0.0",
+            .TExact = "t + x +y, 1.0",
+            .vSource = "-(1-4+1+2*y*(t+2*x^2-2*x*y)+2*x*(t+x^2+y^2)), -(1-4+1-2*x*(t+2*x^2-2*x*y)+(4*x-2*y)*(t+x^2+y^2))",
+            .wSource = "-(1+2*t+3*x^2-2*x*y+y^2)",
+        .qSource=".0"}
+
+    ),
+    [](const testing::TestParamInfo<IncompressibleFlowDynamicSourceMMSParameters> &info) { return info.param.mpiTestParameter.getTestName(); });

--- a/tests/ablateCore/incompressibleFlowFunctionSourceTests.cpp
+++ b/tests/ablateCore/incompressibleFlowFunctionSourceTests.cpp
@@ -287,7 +287,7 @@ static void SourceFunction(f0_incompressible_cubic_w) {
     u = beta cos t + x^3 + y^3
     v = beta sin t + 2x^3 - 3x^2y
     p = 3/2 x^2 + 3/2 y^2 - 1
-    T = 20 cos t + 1/2 x^2 + 1/2 y^2
+    T = beta cos t + 1/2 x^2 + 1/2 y^2
     f = < beta cos t 3x^2         + beta sin t (3y^2 - 1) + 3x^5 + 6x^3y^2 - 6x^2y^3 - \nu(6x + 6y)  + 3x,
           beta cos t (6x^2 - 6xy) - beta sin t (3x^2)     + 3x^4y + 6x^2y^3 - 6xy^4  - \nu(12x - 6y) + 3y>
     Q = beta cos t x + beta sin t (y - 1) + x^4 + 2x^3y - 3x^2y^2 + xy^3 - 2\alpha
@@ -668,66 +668,3 @@ INSTANTIATE_TEST_SUITE_P(
             .f0_v = f0_incompressible_cubic_v,
             .f0_w = f0_incompressible_cubic_w}),
     [](const testing::TestParamInfo<IncompressibleFlowMMSParameters> &info) { return info.param.mpiTestParameter.getTestName(); });
-
-TEST(IncompressibleFlow, ShouldPackIncompressibleFlowParameters) {
-    // arrange
-    IncompressibleFlowParameters parameters{.strouhal = 1.0, .reynolds = 2.0, .peclet = 4.0, .mu = 7.0, .k = 8.0, .cp = 9.0};
-
-    PetscScalar packedConstants[TOTAL_INCOMPRESSIBLE_FLOW_PARAMETERS];
-
-    // act
-    IncompressibleFlow_PackParameters(&parameters, packedConstants);
-
-    // assert
-    ASSERT_EQ(1.0, packedConstants[STROUHAL]) << " STROUHAL is incorrect";
-    ASSERT_EQ(2.0, packedConstants[REYNOLDS]) << " REYNOLDS is incorrect";
-    ASSERT_EQ(4.0, packedConstants[PECLET]) << " PECLET is incorrect";
-    ASSERT_EQ(7.0, packedConstants[MU]) << " MU is incorrect";
-    ASSERT_EQ(8.0, packedConstants[K]) << " K is incorrect";
-    ASSERT_EQ(9.0, packedConstants[CP]) << " CP is incorrect";
-}
-
-class IncompressibleFlowParametersSetupTextFixture : public testingResources::MpiTestFixture,
-                                                     public ::testing::WithParamInterface<std::tuple<testingResources::MpiTestParameter, IncompressibleFlowParameters>> {
-   public:
-    void SetUp() override { SetMpiParameters(std::get<0>(GetParam())); }
-};
-
-TEST_P(IncompressibleFlowParametersSetupTextFixture, ShouldParseFromPetscOptions) {
-    StartWithMPI
-        // arrange
-        PetscErrorCode ierr = PetscInitialize(argc, argv, NULL, "");
-        CHKERRABORT(PETSC_COMM_WORLD, ierr);
-
-        PetscBag petscFlowParametersBag;
-        IncompressibleFlowParameters *actualParameters;
-
-        // act
-        IncompressibleFlow_ParametersFromPETScOptions(&petscFlowParametersBag);
-        PetscBagGetData(petscFlowParametersBag, (void **)&actualParameters);
-
-        // assert
-        auto expectedParameters = std::get<1>(GetParam());
-        ASSERT_EQ(actualParameters->strouhal, expectedParameters.strouhal) << " STROUHAL is incorrect";
-        ASSERT_EQ(actualParameters->reynolds, expectedParameters.reynolds) << " REYNOLDS is incorrect";
-        ASSERT_EQ(actualParameters->peclet, expectedParameters.peclet) << " PECLET is incorrect";
-        ASSERT_EQ(actualParameters->mu, expectedParameters.mu) << " MU is incorrect";
-        ASSERT_EQ(actualParameters->k, expectedParameters.k) << " K is incorrect";
-        ASSERT_EQ(actualParameters->cp, expectedParameters.cp) << " CP is incorrect";
-
-    EndWithMPI
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    IncompressibleFlow, IncompressibleFlowParametersSetupTextFixture,
-    ::testing::Values(std::make_tuple(testingResources::MpiTestParameter{.testName = "default parameters", .nproc = 1, .arguments = ""},
-                                      IncompressibleFlowParameters{.strouhal = 1.0, .reynolds = 1.0, .peclet = 1.0, .mu = 1.0, .k = 1.0, .cp = 1.0}),
-                      std::make_tuple(testingResources::MpiTestParameter{.testName = "strouhal only", .nproc = 1, .arguments = "-strouhal 10.0"},
-                                      IncompressibleFlowParameters{.strouhal = 10.0, .reynolds = 1.0, .peclet = 1.0, .mu = 1.0, .k = 1.0, .cp = 1.0}),
-                      std::make_tuple(
-                          testingResources::MpiTestParameter{
-                              .testName = "all parameters",
-                              .nproc = 1,
-                              .arguments = "-strouhal 10.0 -reynolds 11.1 -froude 12.2 -peclet 13.3 -heatRelease 14.4 -gamma 15.5 -mu 16.6 -k 17.7 -cp 18.8 -beta 19.9 -gravityDirection 2 -pth 20.2"},
-                          IncompressibleFlowParameters{.strouhal = 10.0, .reynolds = 11.1, .peclet = 13.3, .mu = 16.6, .k = 17.7, .cp = 18.8})),
-    [](const testing::TestParamInfo<std::tuple<testingResources::MpiTestParameter, IncompressibleFlowParameters>> &info) { return std::get<0>(info.param).getTestName(); });

--- a/tests/ablateCore/incompressibleFlowParameterTests.cpp
+++ b/tests/ablateCore/incompressibleFlowParameterTests.cpp
@@ -1,0 +1,73 @@
+static char help[] =
+    "Time-dependent Low Mach Flow in 2d channels with finite elements.\n\
+We solve the incompressible problem in a rectangular\n\
+domain, using a parallel unstructured mesh (DMPLEX) to discretize it.\n\n\n";
+
+#include <petsc.h>
+#include "MpiTestFixture.hpp"
+#include "gtest/gtest.h"
+#include "incompressibleFlow.h"
+#include "mesh.h"
+
+TEST(IncompressibleFlow, ShouldPackIncompressibleFlowParameters) {
+    // arrange
+    IncompressibleFlowParameters parameters{.strouhal = 1.0, .reynolds = 2.0, .peclet = 4.0, .mu = 7.0, .k = 8.0, .cp = 9.0};
+
+    PetscScalar packedConstants[TOTAL_INCOMPRESSIBLE_FLOW_PARAMETERS];
+
+    // act
+    IncompressibleFlow_PackParameters(&parameters, packedConstants);
+
+    // assert
+    ASSERT_EQ(1.0, packedConstants[STROUHAL]) << " STROUHAL is incorrect";
+    ASSERT_EQ(2.0, packedConstants[REYNOLDS]) << " REYNOLDS is incorrect";
+    ASSERT_EQ(4.0, packedConstants[PECLET]) << " PECLET is incorrect";
+    ASSERT_EQ(7.0, packedConstants[MU]) << " MU is incorrect";
+    ASSERT_EQ(8.0, packedConstants[K]) << " K is incorrect";
+    ASSERT_EQ(9.0, packedConstants[CP]) << " CP is incorrect";
+}
+
+class IncompressibleFlowParametersSetupTextFixture : public testingResources::MpiTestFixture,
+                                                     public ::testing::WithParamInterface<std::tuple<testingResources::MpiTestParameter, IncompressibleFlowParameters>> {
+   public:
+    void SetUp() override { SetMpiParameters(std::get<0>(GetParam())); }
+};
+
+TEST_P(IncompressibleFlowParametersSetupTextFixture, ShouldParseFromPetscOptions) {
+    StartWithMPI
+        // arrange
+        PetscErrorCode ierr = PetscInitialize(argc, argv, NULL, "");
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        PetscBag petscFlowParametersBag;
+        IncompressibleFlowParameters *actualParameters;
+
+        // act
+        IncompressibleFlow_ParametersFromPETScOptions(&petscFlowParametersBag);
+        PetscBagGetData(petscFlowParametersBag, (void **)&actualParameters);
+
+        // assert
+        auto expectedParameters = std::get<1>(GetParam());
+        ASSERT_EQ(actualParameters->strouhal, expectedParameters.strouhal) << " STROUHAL is incorrect";
+        ASSERT_EQ(actualParameters->reynolds, expectedParameters.reynolds) << " REYNOLDS is incorrect";
+        ASSERT_EQ(actualParameters->peclet, expectedParameters.peclet) << " PECLET is incorrect";
+        ASSERT_EQ(actualParameters->mu, expectedParameters.mu) << " MU is incorrect";
+        ASSERT_EQ(actualParameters->k, expectedParameters.k) << " K is incorrect";
+        ASSERT_EQ(actualParameters->cp, expectedParameters.cp) << " CP is incorrect";
+
+    EndWithMPI
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IncompressibleFlow, IncompressibleFlowParametersSetupTextFixture,
+    ::testing::Values(std::make_tuple(testingResources::MpiTestParameter{.testName = "default parameters", .nproc = 1, .arguments = ""},
+                                      IncompressibleFlowParameters{.strouhal = 1.0, .reynolds = 1.0, .peclet = 1.0, .mu = 1.0, .k = 1.0, .cp = 1.0}),
+                      std::make_tuple(testingResources::MpiTestParameter{.testName = "strouhal only", .nproc = 1, .arguments = "-strouhal 10.0"},
+                                      IncompressibleFlowParameters{.strouhal = 10.0, .reynolds = 1.0, .peclet = 1.0, .mu = 1.0, .k = 1.0, .cp = 1.0}),
+                      std::make_tuple(
+                          testingResources::MpiTestParameter{
+                              .testName = "all parameters",
+                              .nproc = 1,
+                              .arguments = "-strouhal 10.0 -reynolds 11.1 -froude 12.2 -peclet 13.3 -heatRelease 14.4 -gamma 15.5 -mu 16.6 -k 17.7 -cp 18.8 -beta 19.9 -gravityDirection 2 -pth 20.2"},
+                          IncompressibleFlowParameters{.strouhal = 10.0, .reynolds = 11.1, .peclet = 13.3, .mu = 16.6, .k = 17.7, .cp = 18.8})),
+    [](const testing::TestParamInfo<std::tuple<testingResources::MpiTestParameter, IncompressibleFlowParameters>> &info) { return std::get<0>(info.param).getTestName(); });

--- a/tests/ablateCore/lowMachFlowDynamicSourceTests.cpp
+++ b/tests/ablateCore/lowMachFlowDynamicSourceTests.cpp
@@ -354,7 +354,7 @@ INSTANTIATE_TEST_SUITE_P(
                                               "-fieldsplit_0_pc_type lu -fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_ksp_atol 1e-12 -fieldsplit_pressure_pc_type jacobi "
                                               "-dmts_check -1 -snes_linesearch_type basic "
                                               "-gravityDirection 1 "
-                                              "-momentum_sourcepetscspace_degree 8 -mass_sourcepetscspace_degree 8  -energy_sourcepetscspace_degree 8"},
+                                              "-momentum_source_petscspace_degree 8 -mass_source_petscspace_degree 8  -energy_source_petscspace_degree 8"},
             .uExact = "t + x^2 + y^2, t + 2*x^2 + 2*x*y, 1.0, 1.0",
             .pExact = "x + y -1, 0.0",
             .TExact = "t + x +y +1, 1.0",
@@ -374,7 +374,7 @@ INSTANTIATE_TEST_SUITE_P(
                                               "-fieldsplit_0_pc_type lu -fieldsplit_pressure_ksp_rtol 1e-10 -fieldsplit_pressure_ksp_atol 1e-12 -fieldsplit_pressure_pc_type jacobi "
                                               "-dmts_check -1 -snes_linesearch_type basic "
                                               "-gravityDirection 1 "
-                                              "-momentum_sourcepetscspace_degree 8 -mass_sourcepetscspace_degree 8  -energy_sourcepetscspace_degree 8"},
+                                              "-momentum_source_petscspace_degree 8 -mass_source_petscspace_degree 8  -energy_source_petscspace_degree 8"},
             .uExact = "t + x^3 + y^3, t + 2*x^3 + 3*x^2*y, 1.0, 1.0",
             .pExact = "3/2*x^2 + 3/2*y^2 -1.125, 0.0",
             .TExact = "t + .5*x^2 +.5*y^2 +1, 1.0",

--- a/tests/ablateCore/lowMachFlowDynamicSourceTests.cpp
+++ b/tests/ablateCore/lowMachFlowDynamicSourceTests.cpp
@@ -378,14 +378,19 @@ INSTANTIATE_TEST_SUITE_P(
             .uExact = "t + x^3 + y^3, t + 2*x^3 + 3*x^2*y, 1.0, 1.0",
             .pExact = "3/2*x^2 + 3/2*y^2 -1.125, 0.0",
             .TExact = "t + .5*x^2 +.5*y^2 +1, 1.0",
-            .vSource = "-(3*x + 1/(1 + t + x^2/2 + y^2/2) + (3 * y^2*(t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2) + (3*x^2*(t + x^3 + y^3))/(1 + t + x^2/2 + y^2/2) - (4*x + 1*(6*x + 6*y))), -(3*y - ((12*x + 6*y)) + 1/((1 + t + x^2/2 + y^2/2)) + 1/(1 + t + x^2/2 + y^2/2) + (3 * x^2*(t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2) + ((6*x^2 + 6*x*y)*(t + x^3 + y^3))/(1 + t + x^2/2 + y^2/2))",
+            .vSource = "-(3*x + 1/(1 + t + x^2/2 + y^2/2) + (3 * y^2*(t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2) + (3*x^2*(t + x^3 + y^3))/(1 + t + x^2/2 + y^2/2) - (4*x + 1*(6*x + 6*y))), -(3*y "
+                       "- ((12*x + 6*y)) + 1/((1 + t + x^2/2 + y^2/2)) + 1/(1 + t + x^2/2 + y^2/2) + (3 * x^2*(t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2) + ((6*x^2 + 6*x*y)*(t + x^3 + y^3))/(1 + "
+                       "t + x^2/2 + y^2/2))",
             .wSource = "-(-2 + ((1 + y*(t + 2*x^3 + 3*x^2*y) + x*(t + x^3 + y^3)))/( 1 + t + x^2/2 + y^2/2))",
-            .qSource = "-(-(1/(1 + t + x^2/2 + y^2/2)^2) - ( y * (t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2)^2  + (6 * x^2)/(1 + t + x^2/2 + y^2/2) - (x * (t + x^3 + y^3))/(1 + t + x^2/2 + y^2/2)^2)"}),
+            .qSource =
+                "-(-(1/(1 + t + x^2/2 + y^2/2)^2) - ( y * (t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2)^2  + (6 * x^2)/(1 + t + x^2/2 + y^2/2) - (x * (t + x^3 + y^3))/(1 + t + x^2/2 + y^2/2)^2)"}),
     [](const testing::TestParamInfo<LowMachFlowDynamicSourceMMSParameters> &info) { return info.param.mpiTestParameter.getTestName(); });
 //
 TEST(QuickPar, QuckParser) {
     try {
-        PetscTestingFunction uExact("3*y - ((12*x + 6*y)) + 1/((1 + t + x^2/2 + y^2/2)) + 1/(1 + t + x^2/2 + y^2/2) + (3 * x^2*(t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2) + ((6*x^2 + 6*x*y)*(t + x^3 + y^3))/(1 + t + x^2/2 + y^2/2)");
+        PetscTestingFunction uExact(
+            "3*y - ((12*x + 6*y)) + 1/((1 + t + x^2/2 + y^2/2)) + 1/(1 + t + x^2/2 + y^2/2) + (3 * x^2*(t + 2*x^3 + 3*x^2*y))/(1 + t + x^2/2 + y^2/2) + ((6*x^2 + 6*x*y)*(t + x^3 + y^3))/(1 + t + "
+            "x^2/2 + y^2/2)");
     } catch (std::exception e) {
         std::cout << e.what() << std::endl;
     }

--- a/tests/ablateCore/lowMachFlowFunctionSourceTests.cpp
+++ b/tests/ablateCore/lowMachFlowFunctionSourceTests.cpp
@@ -148,7 +148,7 @@ static PetscReal Sin(PetscReal x) { return PetscSinReal(x); }
     u = t + x^2 + y^2
     v = t + 2x^2 + 2xy
     p = x + y - 1
-    T = t + x + y
+    T = t + x + y +1
     z = {0, 1}
 
   see docs/content/formulations/lowMachFlow/solutions/LowMach_2D_Quadratic_MMS.nb.nb
@@ -232,7 +232,7 @@ static void SourceFunction(f0_lowMach_quadratic_w) {
 
     u = t + x^3 + y^3
     v = t + 2x^3 + 3x^2y
-    p = 3/2 x^2 + 3/2 y^2 - 1
+    p = 3/2 x^2 + 3/2 y^2 - 1.125
     T = t + 1/2 x^2 + 1/2 y^2 + 1
     z = {0, 1}
 
@@ -571,93 +571,3 @@ INSTANTIATE_TEST_SUITE_P(
                         .f0_w = f0_lowMach_cubic_w,
                         .f0_q = f0_lowMach_cubic_q}),
     [](const testing::TestParamInfo<LowMachFlowMMSParameters> &info) { return info.param.mpiTestParameter.getTestName(); });
-
-TEST(LowMachFlow, ShouldPackLowMachFlowParameters) {
-    // arrange
-    LowMachFlowParameters parameters{
-        .strouhal = 1.0, .reynolds = 2.0, .froude = 3.0, .peclet = 4.0, .heatRelease = 5.0, .gamma = 6.0, .pth = 11, .mu = 7.0, .k = 8.0, .cp = 9.0, .beta = 10, .gravityDirection = 12};
-
-    PetscScalar packedConstants[TOTAL_LOW_MACH_FLOW_PARAMETERS];
-
-    // act
-    LowMachFlow_PackParameters(&parameters, packedConstants);
-
-    // assert
-    ASSERT_EQ(1.0, packedConstants[STROUHAL]) << " STROUHAL is incorrect";
-    ASSERT_EQ(2.0, packedConstants[REYNOLDS]) << " REYNOLDS is incorrect";
-    ASSERT_EQ(3.0, packedConstants[FROUDE]) << " FROUDE is incorrect";
-    ASSERT_EQ(4.0, packedConstants[PECLET]) << " PECLET is incorrect";
-    ASSERT_EQ(5.0, packedConstants[HEATRELEASE]) << " HEATRELEASE is incorrect";
-    ASSERT_EQ(6.0, packedConstants[GAMMA]) << " GAMMA is incorrect";
-    ASSERT_EQ(11.0, packedConstants[PTH]) << " PTH is incorrect";
-    ASSERT_EQ(7.0, packedConstants[MU]) << " MU is incorrect";
-    ASSERT_EQ(8.0, packedConstants[K]) << " K is incorrect";
-    ASSERT_EQ(9.0, packedConstants[CP]) << " CP is incorrect";
-    ASSERT_EQ(10.0, packedConstants[BETA]) << " BETA is incorrect";
-    ASSERT_EQ(12.0, packedConstants[GRAVITY_DIRECTION]) << " BETA is incorrect";
-}
-
-class LowMachParametersSetupTextFixture : public testingResources::MpiTestFixture, public ::testing::WithParamInterface<std::tuple<testingResources::MpiTestParameter, LowMachFlowParameters>> {
-   public:
-    void SetUp() override { SetMpiParameters(std::get<0>(GetParam())); }
-};
-
-TEST_P(LowMachParametersSetupTextFixture, ShouldParseFromPetscOptions) {
-    StartWithMPI
-        // arrange
-        PetscErrorCode ierr = PetscInitialize(argc, argv, NULL, "");
-        CHKERRABORT(PETSC_COMM_WORLD, ierr);
-
-        PetscBag petscFlowParametersBag;
-        LowMachFlowParameters *actualParameters;
-
-        // act
-        LowMachFlow_ParametersFromPETScOptions(&petscFlowParametersBag);
-        PetscBagGetData(petscFlowParametersBag, (void **)&actualParameters);
-
-        // assert
-        auto expectedParameters = std::get<1>(GetParam());
-        ASSERT_EQ(actualParameters->strouhal, expectedParameters.strouhal) << " STROUHAL is incorrect";
-        ASSERT_EQ(actualParameters->reynolds, expectedParameters.reynolds) << " REYNOLDS is incorrect";
-        ASSERT_EQ(actualParameters->froude, expectedParameters.froude) << " FROUDE is incorrect";
-        ASSERT_EQ(actualParameters->peclet, expectedParameters.peclet) << " PECLET is incorrect";
-        ASSERT_EQ(actualParameters->heatRelease, expectedParameters.heatRelease) << " HEATRELEASE is incorrect";
-        ASSERT_EQ(actualParameters->gamma, expectedParameters.gamma) << " GAMMA is incorrect";
-        ASSERT_EQ(actualParameters->pth, expectedParameters.pth) << " pth is incorrect";
-        ASSERT_EQ(actualParameters->mu, expectedParameters.mu) << " MU is incorrect";
-        ASSERT_EQ(actualParameters->k, expectedParameters.k) << " K is incorrect";
-        ASSERT_EQ(actualParameters->cp, expectedParameters.cp) << " CP is incorrect";
-        ASSERT_EQ(actualParameters->beta, expectedParameters.beta) << " BETA is incorrect";
-        ASSERT_EQ(actualParameters->gravityDirection, expectedParameters.gravityDirection) << " gravityDirection is incorrect";
-    EndWithMPI
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    LowMachFlow, LowMachParametersSetupTextFixture,
-    ::testing::Values(
-        std::make_tuple(
-            testingResources::MpiTestParameter{.testName = "default parameters", .nproc = 1, .arguments = ""},
-            LowMachFlowParameters{
-                .strouhal = 1.0, .reynolds = 1.0, .froude = 1.0, .peclet = 1.0, .heatRelease = 1.0, .gamma = 1.0, .pth = 1, .mu = 1.0, .k = 1.0, .cp = 1.0, .beta = 1.0, .gravityDirection = 0}),
-        std::make_tuple(
-            testingResources::MpiTestParameter{.testName = "strouhal only", .nproc = 1, .arguments = "-strouhal 10.0"},
-            LowMachFlowParameters{
-                .strouhal = 10.0, .reynolds = 1.0, .froude = 1.0, .peclet = 1.0, .heatRelease = 1.0, .gamma = 1.0, .pth = 1, .mu = 1.0, .k = 1.0, .cp = 1.0, .beta = 1.0, .gravityDirection = 0}),
-        std::make_tuple(
-            testingResources::MpiTestParameter{
-                .testName = "all parameters",
-                .nproc = 1,
-                .arguments = "-strouhal 10.0 -reynolds 11.1 -froude 12.2 -peclet 13.3 -heatRelease 14.4 -gamma 15.5 -mu 16.6 -k 17.7 -cp 18.8 -beta 19.9 -gravityDirection 2 -pth 20.2"},
-            LowMachFlowParameters{.strouhal = 10.0,
-                                  .reynolds = 11.1,
-                                  .froude = 12.2,
-                                  .peclet = 13.3,
-                                  .heatRelease = 14.4,
-                                  .gamma = 15.5,
-                                  .pth = 20.2,
-                                  .mu = 16.6,
-                                  .k = 17.7,
-                                  .cp = 18.8,
-                                  .beta = 19.9,
-                                  .gravityDirection = 2})),
-    [](const testing::TestParamInfo<std::tuple<testingResources::MpiTestParameter, LowMachFlowParameters>> &info) { return std::get<0>(info.param).getTestName(); });

--- a/tests/ablateCore/lowMachFlowParameterTests.cpp
+++ b/tests/ablateCore/lowMachFlowParameterTests.cpp
@@ -1,0 +1,100 @@
+static char help[] =
+    "Time-dependent Low Mach Flow in 2d channels with finite elements.\n\
+We solve the Low Mach flow problem in a rectangular\n\
+domain, using a parallel unstructured mesh (DMPLEX) to discretize it.\n\n\n";
+
+#include <petsc.h>
+#include "MpiTestFixture.hpp"
+#include "gtest/gtest.h"
+#include "lowMachFlow.h"
+#include "mesh.h"
+
+TEST(LowMachFlow, ShouldPackLowMachFlowParameters) {
+    // arrange
+    LowMachFlowParameters parameters{
+        .strouhal = 1.0, .reynolds = 2.0, .froude = 3.0, .peclet = 4.0, .heatRelease = 5.0, .gamma = 6.0, .pth = 11, .mu = 7.0, .k = 8.0, .cp = 9.0, .beta = 10, .gravityDirection = 12};
+
+    PetscScalar packedConstants[TOTAL_LOW_MACH_FLOW_PARAMETERS];
+
+    // act
+    LowMachFlow_PackParameters(&parameters, packedConstants);
+
+    // assert
+    ASSERT_EQ(1.0, packedConstants[STROUHAL]) << " STROUHAL is incorrect";
+    ASSERT_EQ(2.0, packedConstants[REYNOLDS]) << " REYNOLDS is incorrect";
+    ASSERT_EQ(3.0, packedConstants[FROUDE]) << " FROUDE is incorrect";
+    ASSERT_EQ(4.0, packedConstants[PECLET]) << " PECLET is incorrect";
+    ASSERT_EQ(5.0, packedConstants[HEATRELEASE]) << " HEATRELEASE is incorrect";
+    ASSERT_EQ(6.0, packedConstants[GAMMA]) << " GAMMA is incorrect";
+    ASSERT_EQ(11.0, packedConstants[PTH]) << " PTH is incorrect";
+    ASSERT_EQ(7.0, packedConstants[MU]) << " MU is incorrect";
+    ASSERT_EQ(8.0, packedConstants[K]) << " K is incorrect";
+    ASSERT_EQ(9.0, packedConstants[CP]) << " CP is incorrect";
+    ASSERT_EQ(10.0, packedConstants[BETA]) << " BETA is incorrect";
+    ASSERT_EQ(12.0, packedConstants[GRAVITY_DIRECTION]) << " BETA is incorrect";
+}
+
+class LowMachParametersSetupTextFixture : public testingResources::MpiTestFixture, public ::testing::WithParamInterface<std::tuple<testingResources::MpiTestParameter, LowMachFlowParameters>> {
+   public:
+    void SetUp() override { SetMpiParameters(std::get<0>(GetParam())); }
+};
+
+TEST_P(LowMachParametersSetupTextFixture, ShouldParseFromPetscOptions) {
+    StartWithMPI
+        // arrange
+        PetscErrorCode ierr = PetscInitialize(argc, argv, NULL, "");
+        CHKERRABORT(PETSC_COMM_WORLD, ierr);
+
+        PetscBag petscFlowParametersBag;
+        LowMachFlowParameters *actualParameters;
+
+        // act
+        LowMachFlow_ParametersFromPETScOptions(&petscFlowParametersBag);
+        PetscBagGetData(petscFlowParametersBag, (void **)&actualParameters);
+
+        // assert
+        auto expectedParameters = std::get<1>(GetParam());
+        ASSERT_EQ(actualParameters->strouhal, expectedParameters.strouhal) << " STROUHAL is incorrect";
+        ASSERT_EQ(actualParameters->reynolds, expectedParameters.reynolds) << " REYNOLDS is incorrect";
+        ASSERT_EQ(actualParameters->froude, expectedParameters.froude) << " FROUDE is incorrect";
+        ASSERT_EQ(actualParameters->peclet, expectedParameters.peclet) << " PECLET is incorrect";
+        ASSERT_EQ(actualParameters->heatRelease, expectedParameters.heatRelease) << " HEATRELEASE is incorrect";
+        ASSERT_EQ(actualParameters->gamma, expectedParameters.gamma) << " GAMMA is incorrect";
+        ASSERT_EQ(actualParameters->pth, expectedParameters.pth) << " pth is incorrect";
+        ASSERT_EQ(actualParameters->mu, expectedParameters.mu) << " MU is incorrect";
+        ASSERT_EQ(actualParameters->k, expectedParameters.k) << " K is incorrect";
+        ASSERT_EQ(actualParameters->cp, expectedParameters.cp) << " CP is incorrect";
+        ASSERT_EQ(actualParameters->beta, expectedParameters.beta) << " BETA is incorrect";
+        ASSERT_EQ(actualParameters->gravityDirection, expectedParameters.gravityDirection) << " gravityDirection is incorrect";
+    EndWithMPI
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LowMachFlow, LowMachParametersSetupTextFixture,
+    ::testing::Values(
+        std::make_tuple(
+            testingResources::MpiTestParameter{.testName = "default parameters", .nproc = 1, .arguments = ""},
+            LowMachFlowParameters{
+                .strouhal = 1.0, .reynolds = 1.0, .froude = 1.0, .peclet = 1.0, .heatRelease = 1.0, .gamma = 1.0, .pth = 1, .mu = 1.0, .k = 1.0, .cp = 1.0, .beta = 1.0, .gravityDirection = 0}),
+        std::make_tuple(
+            testingResources::MpiTestParameter{.testName = "strouhal only", .nproc = 1, .arguments = "-strouhal 10.0"},
+            LowMachFlowParameters{
+                .strouhal = 10.0, .reynolds = 1.0, .froude = 1.0, .peclet = 1.0, .heatRelease = 1.0, .gamma = 1.0, .pth = 1, .mu = 1.0, .k = 1.0, .cp = 1.0, .beta = 1.0, .gravityDirection = 0}),
+        std::make_tuple(
+            testingResources::MpiTestParameter{
+                .testName = "all parameters",
+                .nproc = 1,
+                .arguments = "-strouhal 10.0 -reynolds 11.1 -froude 12.2 -peclet 13.3 -heatRelease 14.4 -gamma 15.5 -mu 16.6 -k 17.7 -cp 18.8 -beta 19.9 -gravityDirection 2 -pth 20.2"},
+            LowMachFlowParameters{.strouhal = 10.0,
+                                  .reynolds = 11.1,
+                                  .froude = 12.2,
+                                  .peclet = 13.3,
+                                  .heatRelease = 14.4,
+                                  .gamma = 15.5,
+                                  .pth = 20.2,
+                                  .mu = 16.6,
+                                  .k = 17.7,
+                                  .cp = 18.8,
+                                  .beta = 19.9,
+                                  .gravityDirection = 2})),
+    [](const testing::TestParamInfo<std::tuple<testingResources::MpiTestParameter, LowMachFlowParameters>> &info) { return std::get<0>(info.param).getTestName(); });

--- a/tests/ablateCore/outputs/lowMach_dynamicSource_2d_cubic_tri_p3_p2_p2
+++ b/tests/ablateCore/outputs/lowMach_dynamicSource_2d_cubic_tri_p3_p2_p2
@@ -1,0 +1,11 @@
+L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-14 <1E-14 <1E-14
+L_2 Residual: (.*)<expects> <1E-8
+Taylor approximation converging at order (.*)<expects> =1.97
+Timestep: 0000 time = 0        	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-13 <1E-13 <1E-13
+Timestep: 0001 time = 0.1      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0002 time = 0.2      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0003 time = 0.3      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0004 time = 0.4      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-14 <1E-14 <1E-14
+L_2 Residual: (.*)<expects> <1E-8
+Taylor approximation converging at order (.*)<expects> =1.98

--- a/tests/ablateCore/outputs/lowMach_dynamicSource_2d_tri_p3_p2_p2
+++ b/tests/ablateCore/outputs/lowMach_dynamicSource_2d_tri_p3_p2_p2
@@ -1,0 +1,11 @@
+L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-14 <1E-14 <1E-14
+L_2 Residual: (.*)<expects> <1E-8
+Taylor approximation converging at order (.*)<expects> =1.98
+Timestep: 0000 time = 0        	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0001 time = 0.1      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0002 time = 0.2      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0003 time = 0.3      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+Timestep: 0004 time = 0.4      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-8 <1E-7 <1E-8
+L_2 Error: \[(.*), (.*), (.*)\]<expects> <1E-13 <1E-13 <1E-13
+L_2 Residual: (.*)<expects> <1E-8
+Taylor approximation converging at order (.*)<expects> =1.99

--- a/tests/ablateCore/particleTests.cpp
+++ b/tests/ablateCore/particleTests.cpp
@@ -638,7 +638,7 @@ TEST_P(ParticleMMS, ParticleFlowMMSTests) {
         ierr = PetscObjectSetOptionsPrefix((PetscObject)particleTs, "particle_");
         CHKERRABORT(PETSC_COMM_WORLD, ierr);
 
-        ierr = ParticleTracerSetupIntegrator(particles, particleTs, ts);
+        ierr = ParticleTracerSetupIntegrator(particles, particleTs, flowData);
         CHKERRABORT(PETSC_COMM_WORLD, ierr);
 
         // setup the initial conditions for error computing

--- a/tests/ablateCore/support/CMakeLists.txt
+++ b/tests/ablateCore/support/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_sources(coreTests
+        PRIVATE
+        petscTestingFunction.cpp
+        petscTestingFunction.hpp
+        testingAuxFieldUpdater.hpp
+        testingAuxFieldUpdater.cpp
+        )

--- a/tests/ablateCore/support/petscTestingFunction.cpp
+++ b/tests/ablateCore/support/petscTestingFunction.cpp
@@ -35,7 +35,7 @@ PetscErrorCode tests::ablateCore::support::PetscTestingFunction::ApplySolution(P
             u[i] = rawResult[i];
         }
 
-    } catch (std::exception exception) {
+    } catch (std::exception &exception) {
         SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
     }
     PetscFunctionReturn(0);
@@ -65,7 +65,7 @@ PetscErrorCode tests::ablateCore::support::PetscTestingFunction::ApplySolutionTi
             u[i] = rawResult[i + Nf];
         }
 
-    } catch (std::exception exception) {
+    } catch (std::exception &exception) {
         SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
     }
     PetscFunctionReturn(0);

--- a/tests/ablateCore/support/petscTestingFunction.cpp
+++ b/tests/ablateCore/support/petscTestingFunction.cpp
@@ -1,0 +1,72 @@
+#include "petscTestingFunction.hpp"
+
+tests::ablateCore::support::PetscTestingFunction::PetscTestingFunction(std::string formula) {
+    // define the x,y,z and t variables
+    parser.DefineVar("x", &coordinate[0]);
+    parser.DefineVar("y", &coordinate[1]);
+    parser.DefineVar("z", &coordinate[2]);
+    parser.DefineVar("t", &time);
+
+    parser.SetExpr(formula);
+    parser.Eval();
+}
+
+PetscErrorCode tests::ablateCore::support::PetscTestingFunction::ApplySolution(PetscInt dim, PetscReal time, const PetscReal *x, PetscInt Nf, PetscScalar *u, void *ctx) {
+    PetscFunctionBeginUser;
+    try {
+        auto parser = (PetscTestingFunction *)ctx;
+
+        // update the coordinates
+        parser->coordinate[0] = 0;
+        parser->coordinate[1] = 0;
+        parser->coordinate[2] = 0;
+
+        for (auto i = 0; i < std::min(dim, 3); i++) {
+            parser->coordinate[i] = x[i];
+        }
+        parser->time = time;
+
+        // Evaluate
+        int functionSize = 0;
+        auto rawResult = parser->parser.Eval(functionSize);
+
+        // copy over
+        for (auto i = 0; i < Nf; i++) {
+            u[i] = rawResult[i];
+        }
+
+    } catch (std::exception exception) {
+        SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
+    }
+    PetscFunctionReturn(0);
+}
+
+PetscErrorCode tests::ablateCore::support::PetscTestingFunction::ApplySolutionTimeDerivative(PetscInt dim, PetscReal time, const PetscReal *x, PetscInt Nf, PetscScalar *u, void *ctx) {
+    PetscFunctionBeginUser;
+    try {
+        auto parser = (PetscTestingFunction *)ctx;
+
+        // update the coordinates
+        parser->coordinate[0] = 0;
+        parser->coordinate[1] = 0;
+        parser->coordinate[2] = 0;
+
+        for (auto i = 0; i < std::min(dim, 3); i++) {
+            parser->coordinate[i] = x[i];
+        }
+        parser->time = time;
+
+        // Evaluate
+        int functionSize = 0;
+        auto rawResult = parser->parser.Eval(functionSize);
+
+        // copy over
+        for (auto i = 0; i < Nf; i++) {
+            u[i] = rawResult[i + Nf];
+        }
+
+    } catch (std::exception exception) {
+        SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
+    }
+    PetscFunctionReturn(0);
+}

--- a/tests/ablateCore/support/petscTestingFunction.hpp
+++ b/tests/ablateCore/support/petscTestingFunction.hpp
@@ -11,8 +11,8 @@ class PetscTestingFunction {
     mu::Parser parser;
 
    public:
-    PetscTestingFunction(const PetscTestingFunction&) = delete;
-    void operator=(const PetscTestingFunction&) = delete;
+    PetscTestingFunction(const PetscTestingFunction &) = delete;
+    void operator=(const PetscTestingFunction &) = delete;
     explicit PetscTestingFunction(std::string formula);
     static PetscErrorCode ApplySolution(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar *u, void *ctx);
     static PetscErrorCode ApplySolutionTimeDerivative(PetscInt dim, PetscReal time, const PetscReal *x, PetscInt Nf, PetscScalar *u, void *ctx);

--- a/tests/ablateCore/support/petscTestingFunction.hpp
+++ b/tests/ablateCore/support/petscTestingFunction.hpp
@@ -1,0 +1,22 @@
+#ifndef ABLATELIBRARY_PETSCTESTINGFUNCTION_HPP
+#define ABLATELIBRARY_PETSCTESTINGFUNCTION_HPP
+#include <muParser.h>
+#include <petsc.h>
+
+namespace tests::ablateCore::support {
+class PetscTestingFunction {
+   private:
+    double coordinate[3] = {0, 0, 0};
+    double time = 0.0;
+    mu::Parser parser;
+
+   public:
+    PetscTestingFunction(const PetscTestingFunction&) = delete;
+    void operator=(const PetscTestingFunction&) = delete;
+    explicit PetscTestingFunction(std::string formula);
+    static PetscErrorCode ApplySolution(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar *u, void *ctx);
+    static PetscErrorCode ApplySolutionTimeDerivative(PetscInt dim, PetscReal time, const PetscReal *x, PetscInt Nf, PetscScalar *u, void *ctx);
+};
+}  // namespace tests::ablateCore::support
+
+#endif  // ABLATELIBRARY_PETSCTESTINGFUNCTION_HPP

--- a/tests/ablateCore/support/testingAuxFieldUpdater.cpp
+++ b/tests/ablateCore/support/testingAuxFieldUpdater.cpp
@@ -1,0 +1,29 @@
+#include "testingAuxFieldUpdater.hpp"
+#include "flow.h"
+
+PetscErrorCode tests::ablateCore::support::TestingAuxFieldUpdater::UpdateSourceTerms(TS ts, void *ctx) {
+    PetscFunctionBegin;
+    auto sourceTermUpdater = (TestingAuxFieldUpdater *)ctx;
+
+    // extract the flow data from ts
+    DM dm;
+    PetscErrorCode ierr = TSGetDM(ts, &dm);
+    CHKERRQ(ierr);
+    FlowData flowData;
+    ierr = DMGetApplicationContext(dm, &flowData);
+    CHKERRQ(ierr);
+
+    // get the time at the end of the time step
+    PetscReal time;
+    ierr = TSGetTime(ts, &time);
+    CHKERRQ(ierr);
+    PetscReal dt;
+    ierr = TSGetTimeStep(ts, &dt);
+    CHKERRQ(ierr);
+
+    // Update the source terms
+    ierr = DMProjectFunctionLocal(flowData->auxDm, time + dt, &(sourceTermUpdater->funcs[0]), &(sourceTermUpdater->ctxs[0]), INSERT_ALL_VALUES, flowData->auxField);
+    CHKERRQ(ierr);
+
+    PetscFunctionReturn(0);
+}

--- a/tests/ablateCore/support/testingAuxFieldUpdater.hpp
+++ b/tests/ablateCore/support/testingAuxFieldUpdater.hpp
@@ -1,0 +1,23 @@
+#ifndef ABLATELIBRARY_TESTINGAUXFIELDUPDATER_HPP
+#define ABLATELIBRARY_TESTINGAUXFIELDUPDATER_HPP
+#include <petsc.h>
+#include <vector>
+#include "petscTestingFunction.hpp"
+namespace tests::ablateCore::support {
+typedef PetscErrorCode (*SolutionFunction)(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar *u, void *ctx);
+
+class TestingAuxFieldUpdater {
+   private:
+    std::vector<SolutionFunction> funcs;
+    std::vector<void *> ctxs;
+
+   public:
+    void AddField(PetscTestingFunction &field) {
+        funcs.push_back(PetscTestingFunction::ApplySolution);
+        ctxs.push_back(&field);
+    }
+    static PetscErrorCode UpdateSourceTerms(TS ts, void *ctx);
+};
+}  // namespace tests::ablateCore::support
+
+#endif  // ABLATELIBRARY_TESTINGAUXFIELDUPDATER_HPP

--- a/tests/ablateCore/support/testingAuxFieldUpdater.hpp
+++ b/tests/ablateCore/support/testingAuxFieldUpdater.hpp
@@ -3,7 +3,9 @@
 #include <petsc.h>
 #include <vector>
 #include "petscTestingFunction.hpp"
+
 namespace tests::ablateCore::support {
+
 typedef PetscErrorCode (*SolutionFunction)(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar *u, void *ctx);
 
 class TestingAuxFieldUpdater {

--- a/tests/ablateLibrary/parser/factoryTests.cpp
+++ b/tests/ablateLibrary/parser/factoryTests.cpp
@@ -10,6 +10,38 @@ namespace ablateTesting::parser {
 
 using namespace ablate::parser;
 
+class FactoryMockClass1 {};
+
+TEST(FactoryTests, GetShouldReturnNullPtrWhenOptional) {
+    // arrange
+
+    ablate::parser::Registrar<FactoryMockClass1>::Register<FactoryMockClass1>(true, "FactoryMockClass1", "this is a simple mock class");
+    auto mockFactory = std::make_shared<MockFactory>();
+    EXPECT_CALL(*mockFactory, Contains(std::string("input123"))).Times(::testing::Exactly(1)).WillOnce(::testing::Return(false));
+
+    // act
+    auto argument = ArgumentIdentifier<FactoryMockClass1>{.inputName = "input123", .optional = true};
+    auto result = std::dynamic_pointer_cast<Factory>(mockFactory)->Get(argument);
+
+    // assert
+    ASSERT_TRUE(result == nullptr);
+}
+
+TEST(FactoryTests, ShouldReturnEmptyListWhenOptional) {
+    // arrange
+
+    ablate::parser::Registrar<FactoryMockClass1>::Register<FactoryMockClass1>(true, "FactoryMockClass1", "this is a simple mock class");
+    auto mockFactory = std::make_shared<MockFactory>();
+    EXPECT_CALL(*mockFactory, Contains(std::string("input123"))).Times(::testing::Exactly(1)).WillOnce(::testing::Return(false));
+
+    // act
+    auto argument = ArgumentIdentifier<std::vector<FactoryMockClass1>>{.inputName = "input123", .optional = true};
+    auto result = std::dynamic_pointer_cast<Factory>(mockFactory)->Get(argument);
+
+    // assert
+    ASSERT_TRUE(result.empty());
+}
+
 TEST(FactoryTests, GetByNameShouldCallGetWithCorrectArguments) {
     // arrange
     MockFactory mockFactory;

--- a/tests/ablateLibrary/parser/registrarTests.cpp
+++ b/tests/ablateLibrary/parser/registrarTests.cpp
@@ -79,6 +79,37 @@ TEST(RegistrarTests, ShouldRegisterClassWithArgumentIdentifiersAndRecordInLog) {
     Listing::ReplaceListing(nullptr);
 }
 
+TEST(RegistrarTests, ShouldRegisterClassWithArgumentIdentifiersAndOptAndRecordInLog) {
+    // arrange
+    auto mockListing = std::make_shared<MockListing>();
+    EXPECT_CALL(*mockListing,
+                RecordListing(Listing::ClassEntry{
+                    .interface = typeid(MockInterface).name(),
+                    .className = "MockClass2a",
+                    .description = "this is a simple mock class",
+                    .arguments = {Listing::ArgumentEntry{.name = "dog", .interface = typeid(std::string).name(), .description = "this is a string", .optional = true},
+                                  Listing::ArgumentEntry{.name = "cat", .interface = typeid(int).name(), .description = "this is a int", .optional = true},
+                                  Listing::ArgumentEntry{.name = "bird", .interface = typeid(MockInterface).name(), .description = "this is a shared pointer to an interface", .optional = true}}}))
+        .Times(::testing::Exactly(1));
+
+    Listing::ReplaceListing(mockListing);
+
+    // act
+    ablate::parser::Registrar<MockInterface>::Register<MockClass2>(false,
+                                                                   "MockClass2a",
+                                                                   "this is a simple mock class",
+                                                                   ablate::parser::ArgumentIdentifier<std::string>{"dog", "this is a string", true},
+                                                                   ablate::parser::ArgumentIdentifier<int>{"cat", "this is a int", true},
+                                                                   ablate::parser::ArgumentIdentifier<MockInterface>{"bird", "this is a shared pointer to an interface", true});
+
+    // assert
+    auto createMethod = Registrar<MockInterface>::GetCreateMethod("MockClass2a");
+    ASSERT_TRUE(createMethod != nullptr);
+
+    // cleanup
+    Listing::ReplaceListing(nullptr);
+}
+
 class MockInterface4 {
     virtual void Test(){};
 };

--- a/tests/ablateLibrary/parser/yamlParserTests.cpp
+++ b/tests/ablateLibrary/parser/yamlParserTests.cpp
@@ -73,6 +73,21 @@ TEST(YamlParserTests, ShouldThrowErrorForMissingString) {
     ASSERT_THROW(yamlParser->Get(ArgumentIdentifier<std::string>{"itemNotThere"}), std::invalid_argument);
 }
 
+TEST(YamlParserTests, ShouldReturnCorrectStringForOptionalValue) {
+    // arrange
+    std::stringstream yaml;
+    yaml << "---" << std::endl;
+    yaml << " item: im_a_string " << std::endl;
+    std::string emptyString = {};
+
+    // act
+    auto yamlParser = std::make_shared<YamlParser>(yaml.str());
+    // assert
+    ASSERT_EQ("im_a_string", yamlParser->Get(ArgumentIdentifier<std::string>{"item", .optional = true}));
+    ASSERT_EQ(emptyString, yamlParser->Get(ArgumentIdentifier<std::string>{"item 2", .optional = true}));
+    ASSERT_EQ("", yamlParser->GetClassType());
+}
+
 TEST(YamlParserTests, ShouldParseInts) {
     // arrange
     std::stringstream yaml;
@@ -103,6 +118,21 @@ TEST(YamlParserTests, ShouldThrowErrorForMissingInt) {
 
     // assert
     ASSERT_THROW(yamlParser->Get(ArgumentIdentifier<std::string>{"itemNotThere"}), std::invalid_argument);
+}
+
+TEST(YamlParserTests, ShouldReturnCorrectInForOptionalValue) {
+    // arrange
+    std::stringstream yaml;
+    yaml << "---" << std::endl;
+    yaml << " item: 22" << std::endl;
+    int defaultValue = {};
+
+    // act
+    auto yamlParser = std::make_shared<YamlParser>(yaml.str());
+
+    // assert
+    ASSERT_EQ(22, yamlParser->Get(ArgumentIdentifier<int>{"item", .optional = true}));
+    ASSERT_EQ(defaultValue, yamlParser->Get(ArgumentIdentifier<int>{"item 2", .optional = true}));
 }
 
 TEST(YamlParserTests, ShouldParseSubFactory) {
@@ -246,6 +276,22 @@ TEST(YamlParserTests, ShouldGetListOfStrings) {
     ASSERT_EQ(list, expectedValues);
 }
 
+TEST(YamlParserTests, ShouldGetCorrectValueForOptionalListOfStrings) {
+    // arrange
+    std::stringstream yaml;
+    yaml << "---" << std::endl;
+    yaml << " item1: 22" << std::endl;
+
+    auto yamlParser = std::make_shared<YamlParser>(yaml.str());
+
+    // act
+    auto list = yamlParser->Get(ArgumentIdentifier<std::vector<std::string>>{"item2", .optional = true});
+
+    // assert
+    std::vector<std::string> expectedValues = {};
+    ASSERT_EQ(list, expectedValues);
+}
+
 TEST(YamlParserTests, ShouldGetMapOfStrings) {
     // arrange
     std::stringstream yaml;
@@ -263,6 +309,22 @@ TEST(YamlParserTests, ShouldGetMapOfStrings) {
 
     // assert
     std::map<std::string, std::string> expectedValues = {{"string1", "1"}, {"string2", "2"}, {"string3", "3"}};
+    ASSERT_EQ(map, expectedValues);
+}
+
+TEST(YamlParserTests, ShouldGetCorrectValueForOptionalMap) {
+    // arrange
+    std::stringstream yaml;
+    yaml << "---" << std::endl;
+    yaml << " item1: 22" << std::endl;
+
+    auto yamlParser = std::make_shared<YamlParser>(yaml.str());
+
+    // act
+    auto map = yamlParser->Get(ArgumentIdentifier<std::map<std::string, std::string>>{"item2", .optional = true});
+
+    // assert
+    std::map<std::string, std::string> expectedValues = {};
     ASSERT_EQ(map, expectedValues);
 }
 

--- a/tests/integrationTests/inputs/tracerParticles2DHDF5Monitor.yaml
+++ b/tests/integrationTests/inputs/tracerParticles2DHDF5Monitor.yaml
@@ -29,6 +29,7 @@ flow: !ablate::flow::IncompressibleFlow
     dimensions: 2
     arguments:
       dm_refine: 2
+      dm_distribute: true
       vel_petscspace_degree: 2
       pres_petscspace_degree: 1
       temp_petscspace_degree: 1

--- a/tests/integrationTests/tests.cpp
+++ b/tests/integrationTests/tests.cpp
@@ -21,10 +21,16 @@ TEST_P(IntegrationTestsSpecifier, ShouldRun) {
         PetscErrorCode ierr = PetscInitialize(argc, argv, NULL, help);
         CHKERRABORT(PETSC_COMM_WORLD, ierr);
         {
+            int rank;
+            MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
+
             // precompute the resultDirectory directory so we can remove it if it here
             auto testName = GetParam().getTestName();
             std::filesystem::path resultDirectory = std::filesystem::current_path() / testName;
-            std::filesystem::remove_all(resultDirectory);
+            if(rank == 0) {
+                std::filesystem::remove_all(resultDirectory);
+            }
+            MPI_Barrier(PETSC_COMM_WORLD);
 
             // get the file
             std::filesystem::path inputPath = GetParam().testName;
@@ -40,15 +46,17 @@ TEST_P(IntegrationTestsSpecifier, ShouldRun) {
             ablate::Builder::Run(parser);
 
             // print all files in the directory so that they are compared with expected
-            std::vector<std::string> resultFileInfo;
-            for (const auto& entry : fs::directory_iterator(ablate::monitors::RunEnvironment::Get().GetOutputDirectory())) {
-                resultFileInfo.push_back(entry.path().filename());
-            }
-            // sort the names so that the output order is defined
-            std::sort(resultFileInfo.begin(), resultFileInfo.end());
-            std::cout << "ResultFiles:" << std::endl;
-            for (const auto& fileInfo : resultFileInfo) {
-                std::cout << fileInfo << std::endl;
+            if(rank == 0) {
+                std::vector<std::string> resultFileInfo;
+                for (const auto& entry : fs::directory_iterator(ablate::monitors::RunEnvironment::Get().GetOutputDirectory())) {
+                    resultFileInfo.push_back(entry.path().filename());
+                }
+                // sort the names so that the output order is defined
+                std::sort(resultFileInfo.begin(), resultFileInfo.end());
+                std::cout << "ResultFiles:" << std::endl;
+                for (const auto& fileInfo : resultFileInfo) {
+                    std::cout << fileInfo << std::endl;
+                }
             }
         }
         ierr = PetscFinalize();
@@ -59,6 +67,6 @@ TEST_P(IntegrationTestsSpecifier, ShouldRun) {
 INSTANTIATE_TEST_SUITE_P(Tests, IntegrationTestsSpecifier,
                          testing::Values((MpiTestParameter){.testName = "inputs/incompressibleFlow.yaml", .nproc = 1, .expectedOutputFile = "outputs/incompressibleFlow.txt", .arguments = ""},
                                          (MpiTestParameter){
-                                             .testName = "inputs/tracerParticles2DHDF5Monitor.yaml", .nproc = 1, .expectedOutputFile = "outputs/tracerParticles2DHDF5Monitor.txt", .arguments = ""},
+                                             .testName = "inputs/tracerParticles2DHDF5Monitor.yaml", .nproc = 2, .expectedOutputFile = "outputs/tracerParticles2DHDF5Monitor.txt", .arguments = ""},
                                          (MpiTestParameter){.testName = "inputs/tracerParticles3D.yaml", .nproc = 1, .expectedOutputFile = "outputs/tracerParticles3D.txt", .arguments = ""}),
                          [](const testing::TestParamInfo<MpiTestParameter>& info) { return info.param.getTestName(); });

--- a/tests/integrationTests/tests.cpp
+++ b/tests/integrationTests/tests.cpp
@@ -27,7 +27,7 @@ TEST_P(IntegrationTestsSpecifier, ShouldRun) {
             // precompute the resultDirectory directory so we can remove it if it here
             auto testName = GetParam().getTestName();
             std::filesystem::path resultDirectory = std::filesystem::current_path() / testName;
-            if(rank == 0) {
+            if (rank == 0) {
                 std::filesystem::remove_all(resultDirectory);
             }
             MPI_Barrier(PETSC_COMM_WORLD);
@@ -46,7 +46,7 @@ TEST_P(IntegrationTestsSpecifier, ShouldRun) {
             ablate::Builder::Run(parser);
 
             // print all files in the directory so that they are compared with expected
-            if(rank == 0) {
+            if (rank == 0) {
                 std::vector<std::string> resultFileInfo;
                 for (const auto& entry : fs::directory_iterator(ablate::monitors::RunEnvironment::Get().GetOutputDirectory())) {
                     resultFileInfo.push_back(entry.path().filename());


### PR DESCRIPTION
- aux field creation upon request
- unifies fe field creation for flows
- adds tests for string based source terms
- moves pre/post steps into flow and allows for multiple
- cleans up tests by moving them to separate files
- support in parser/tests
- closes #33 