### PR TITLE
added support for dmPlex set from options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_get_variable(PETSC_CXX_COMPILER PETSc cxxcompiler)
 set(CMAKE_CXX_COMPILER ${PETSC_CXX_COMPILER})
 
 # Set the project details
-project(ablateLibrary VERSION 0.4.1)
+project(ablateLibrary VERSION 0.4.2)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED PETSc)

--- a/ablateLibrary/mesh/CMakeLists.txt
+++ b/ablateLibrary/mesh/CMakeLists.txt
@@ -5,4 +5,6 @@ target_sources(ablateLibrary
         boxMesh.cpp
         dmWrapper.hpp
         dmWrapper.cpp
+        dmPlex.hpp
+        dmPlex.cpp
         )

--- a/ablateLibrary/mesh/dmPlex.cpp
+++ b/ablateLibrary/mesh/dmPlex.cpp
@@ -1,0 +1,29 @@
+#include "dmPlex.hpp"
+#include <utilities/petscError.hpp>
+#include <utilities/petscOptions.hpp>
+
+ablate::mesh::DMPlex::DMPlex(std::string nameIn, std::shared_ptr<parameters::Parameters> options) : Mesh(nameIn), petscOptions(NULL) {
+    // Set the options if provided
+    if (options) {
+        PetscOptionsCreate(&petscOptions) >> checkError;
+        options->Fill(petscOptions);
+    }
+
+    DMCreate(PETSC_COMM_WORLD, &dm) >> checkError;
+    DMSetType(dm, DMPLEX) >> checkError;
+    PetscObjectSetName((PetscObject)dm, name.c_str()) >> checkError;
+    PetscObjectSetOptions((PetscObject)dm, petscOptions) >> checkError;
+    DMSetFromOptions(dm) >> checkError;
+}
+
+ablate::mesh::DMPlex::~DMPlex() {
+    if (dm) {
+        DMDestroy(&dm);
+    }
+    if (petscOptions) {
+        ablate::utilities::PetscOptionsDestroyAndCheck(name, &petscOptions);
+    }
+}
+
+#include "parser/registrar.hpp"
+REGISTER(ablate::mesh::Mesh, ablate::mesh::DMPlex, "DMPlex that can be set using PETSc options", ARG(std::string, "name", "the mesh dm name"), OPT(ablate::parameters::Parameters, "options", "options used to setup the DMPlex"));

--- a/ablateLibrary/mesh/dmPlex.cpp
+++ b/ablateLibrary/mesh/dmPlex.cpp
@@ -26,4 +26,5 @@ ablate::mesh::DMPlex::~DMPlex() {
 }
 
 #include "parser/registrar.hpp"
-REGISTER(ablate::mesh::Mesh, ablate::mesh::DMPlex, "DMPlex that can be set using PETSc options", ARG(std::string, "name", "the mesh dm name"), OPT(ablate::parameters::Parameters, "options", "options used to setup the DMPlex"));
+REGISTER(ablate::mesh::Mesh, ablate::mesh::DMPlex, "DMPlex that can be set using PETSc options", ARG(std::string, "name", "the mesh dm name"),
+         OPT(ablate::parameters::Parameters, "options", "options used to setup the DMPlex"));

--- a/ablateLibrary/mesh/dmPlex.hpp
+++ b/ablateLibrary/mesh/dmPlex.hpp
@@ -7,7 +7,7 @@
 
 namespace ablate::mesh {
 
-class DMPlex : public Mesh{
+class DMPlex : public Mesh {
    private:
     // Petsc options specific to the mesh. These may be null by default
     PetscOptions petscOptions;
@@ -16,6 +16,6 @@ class DMPlex : public Mesh{
     DMPlex(std::string name = "dmplex", std::shared_ptr<parameters::Parameters> options = {});
     ~DMPlex();
 };
-}
+}  // namespace ablate::mesh
 
 #endif  // ABLATELIBRARY_DMPLEX_HPP

--- a/ablateLibrary/mesh/dmPlex.hpp
+++ b/ablateLibrary/mesh/dmPlex.hpp
@@ -1,0 +1,21 @@
+#ifndef ABLATELIBRARY_DMPLEX_HPP
+#define ABLATELIBRARY_DMPLEX_HPP
+
+#include <memory>
+#include <parameters/parameters.hpp>
+#include "mesh.hpp"
+
+namespace ablate::mesh {
+
+class DMPlex : public Mesh{
+   private:
+    // Petsc options specific to the mesh. These may be null by default
+    PetscOptions petscOptions;
+
+   public:
+    DMPlex(std::string name = "dmplex", std::shared_ptr<parameters::Parameters> options = {});
+    ~DMPlex();
+};
+}
+
+#endif  // ABLATELIBRARY_DMPLEX_HPP

--- a/tests/ablateLibrary/CMakeLists.txt
+++ b/tests/ablateLibrary/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(environment)
 add_subdirectory(flow)
 add_subdirectory(particles)
 add_subdirectory(eos)
+add_subdirectory(mesh)
 
 gtest_discover_tests(libraryTests
         # set a working directory so your project root so that you can find test data via paths relative to the project root

--- a/tests/ablateLibrary/mesh/CMakeLists.txt
+++ b/tests/ablateLibrary/mesh/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(libraryTests
+        PRIVATE
+        dmPlexTests.cpp
+        )

--- a/tests/ablateLibrary/mesh/dmPlexTests.cpp
+++ b/tests/ablateLibrary/mesh/dmPlexTests.cpp
@@ -1,0 +1,45 @@
+#include <petsc.h>
+#include <cmath>
+#include <memory>
+#include "MpiTestFixture.hpp"
+#include "PetscTestErrorChecker.hpp"
+#include "gtest/gtest.h"
+#include "mesh/dmPlex.hpp"
+
+using namespace ablate;
+
+struct DMPlexParameters {
+    testingResources::MpiTestParameter mpiTestParameter;
+    // Optional parameters passed to dmPlex object (can be null)
+    std::shared_ptr<parameters::Parameters> parameters;
+};
+
+class DMPlexTestFixture : public testingResources::MpiTestFixture, public ::testing::WithParamInterface<DMPlexParameters> {
+   public:
+    void SetUp() override { SetMpiParameters(GetParam().mpiTestParameter); }
+};
+
+TEST_P(DMPlexTestFixture, ShouldCreateAndViewDMPlex) {
+    StartWithMPI
+        {
+            // arrange
+            // initialize petsc and mpi
+            PetscInitialize(argc, argv, NULL, NULL) >> testErrorChecker;
+
+            // Get the testing param
+            auto &testingParam = GetParam();
+
+            // act
+            auto dmPlex = std::make_shared<ablate::mesh::DMPlex>("dmPlex", testingParam.parameters);
+
+            // assert - print the dmPlex to standard out
+            DMView(dmPlex->GetDomain(), PETSC_VIEWER_STDOUT_WORLD) >> testErrorChecker;
+        }
+        exit(PetscFinalize());
+    EndWithMPI
+}
+
+INSTANTIATE_TEST_SUITE_P(MeshTests, DMPlexTestFixture,
+                         testing::Values((DMPlexParameters){.mpiTestParameter = {.testName = "default DMPlex", .nproc = 1, .expectedOutputFile = "outputs/mesh/dmPlex_NoArguments", .arguments = ""},
+                                                            .parameters = nullptr}),
+                         [](const testing::TestParamInfo<DMPlexParameters> &info) { return info.param.mpiTestParameter.getTestName(); });

--- a/tests/ablateLibrary/outputs/mesh/dmPlex_NoArguments
+++ b/tests/ablateLibrary/outputs/mesh/dmPlex_NoArguments
@@ -1,0 +1,5 @@
+DM Object: dmPlex 1 MPI processes
+  type: plex
+dmPlex in 0 dimensions:
+Labels:
+  celltype: 0 strata with value/size ()


### PR DESCRIPTION
 Missing real tests until PETSc 3.16 is released with DMPlex set from options, so I think we should leave issue #72 open until testing is complete.  Should we merge this in now if we think that it will be useful. 