### PR TITLE
yaml file override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_get_variable(PETSC_CXX_COMPILER PETSc cxxcompiler)
 set(CMAKE_CXX_COMPILER ${PETSC_CXX_COMPILER})
 
 # Set the project details
-project(ablateLibrary VERSION 0.4.14)
+project(ablateLibrary VERSION 0.4.15)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED PETSc)

--- a/ablateCore/CMakeLists.txt
+++ b/ablateCore/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(ablateCore "")
 # Include PETSc and MPI
 target_include_directories(ablateCore PUBLIC ${PETSc_INCLUDE_DIRS})
 target_link_libraries(ablateCore PUBLIC ${PETSc_LIBRARIES})
-target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS} /opt/homebrew/Cellar/gcc/11.1.0_1/lib/gcc/11)
+target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS})
 
 # Allow public access to the header files in the directory
 target_include_directories(ablateCore PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/ablateCore/CMakeLists.txt
+++ b/ablateCore/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(ablateCore "")
 # Include PETSc and MPI
 target_include_directories(ablateCore PUBLIC ${PETSc_INCLUDE_DIRS})
 target_link_libraries(ablateCore PUBLIC ${PETSc_LIBRARIES})
-target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS})
+target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS} /opt/homebrew/Cellar/gcc/11.1.0_1/lib/gcc/11)
 
 # Allow public access to the header files in the directory
 target_include_directories(ablateCore PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/ablateLibrary/environment/runEnvironment.cpp
+++ b/ablateLibrary/environment/runEnvironment.cpp
@@ -50,11 +50,6 @@ ablate::environment::RunEnvironment::RunEnvironment(const parameters::Parameters
     if (mpiRank == 0) {
         // make the output directory
         std::filesystem::create_directories(outputDirectory);
-
-        // copy over the input file
-        if (!inputPath.empty()) {
-            std::filesystem::copy(inputPath, outputDirectory / inputPath.filename(), std::filesystem::copy_options::overwrite_existing);
-        }
     }
 }
 

--- a/ablateLibrary/parameters/mapParameters.cpp
+++ b/ablateLibrary/parameters/mapParameters.cpp
@@ -17,3 +17,9 @@ std::unordered_set<std::string> ablate::parameters::MapParameters::GetKeys() con
     }
     return keys;
 }
+
+ablate::parameters::MapParameters::MapParameters(std::initializer_list<std::pair<std::string, std::string>> list) {
+    for (const auto& pair : list) {
+        values[pair.first] = pair.second;
+    }
+}

--- a/ablateLibrary/parameters/mapParameters.hpp
+++ b/ablateLibrary/parameters/mapParameters.hpp
@@ -1,16 +1,19 @@
 #ifndef ABLATELIBRARY_MAPPARAMETERS_HPP
 #define ABLATELIBRARY_MAPPARAMETERS_HPP
 
+#include <initializer_list>
 #include <iostream>
 #include <map>
 #include <memory>
 #include "parameters.hpp"
+
 namespace ablate::parameters {
 class MapParameters : public Parameters {
    protected:
     std::map<std::string, std::string> values;
 
    public:
+    MapParameters(std::initializer_list<std::pair<std::string, std::string>>);
     MapParameters(std::map<std::string, std::string> values = {});
     std::optional<std::string> GetString(std::string paramName) const override;
     std::unordered_set<std::string> GetKeys() const override;

--- a/ablateLibrary/parameters/petscPrefixOptions.cpp
+++ b/ablateLibrary/parameters/petscPrefixOptions.cpp
@@ -19,7 +19,7 @@ ablate::parameters::PetscPrefixOptions::PetscPrefixOptions(std::string prefix) :
         std::string subString;
         keyAndOptions >> subString;
 
-        // if this options starts with the previx
+        // if this options starts with the prefix
         if (subString.find(prefix) == 0) {
             char value[PETSC_MAX_VALUE_SIZE];
             // Get the value from petsc

--- a/docs/content/parser/RunningSimulations.md
+++ b/docs/content/parser/RunningSimulations.md
@@ -6,29 +6,8 @@ parent: Input Files
 ---
 ABLATE includes a yaml parser for setting up and configuring simulations.  The yaml input files specifies all of the details of the simulation without the need to recompile the code.   These directions assume you have built ABLATE as outlined in [Building ABLATE Locally]({{ site.baseurl}}{%link content/development/BuildingABLATELocally.md  %}).  There are a variety of ways to build and interact with ABLATE including the command line and integrated development environments (IDEs). This document will cover using ablate built with the command line and [CLion](https://www.jetbrains.com/clion/).
 
-## Obtaining an Input File
+## Obtaining Input Files
 Download an example file and move to a location on your computer (should be placed outside the ablate repository).  Example files used for [integration testing are available](https://github.com/UBCHREST/ablate/tree/main/tests/integrationTests/inputs). 
-
-## Running ABLATE from the Command Line
-If you built ABLATE using the command line you can run ABLATE using either the debug or release builds.
-    
-    ```bash
-    # navigate to either the debug or release directory of ABLATE
-    ./ablate --input /path/to/the/inputfile.yaml
-
-    # similarly, ABLATE can be run using mpi
-    mpirun -n 3 ./abalte --input /path/to/the/inputfile.yaml
-    ```
-
-Other available command line arguments are listed in [Parser Command Line Arguments](#parser-command-line-arguments).
-
-## Running ABLATE from CLion
-1. If you are new to CLion it is recommend that you read through the [CLion Quick Start Guide](https://www.jetbrains.com/help/clion/clion-quick-start-guide.html).
-1. Select the ablate configuration from the configuration drop down.
-    ![clion ablate configuration selection](assets/clion_ablate_configuration.png)
-1. Under the same menu select "Edit Configurations..." and enter the input file argument as shown.  Other available command line arguments are listed in [Parser Command Line Arguments](#parser-command-line-arguments).
-    ![clion ablate configuration setup](assets/clion_ablate_configuration_setup.png)
-1. Run or Debug ABLATE using the icons in the toolbar or under the Run menu.
 
 ## Yaml Input Files
 At this point in time there is only a single YAML based implementation of a parser/factory. In this implementation arguments are passed as dictionary objects and lists.  When a class must be specified in YAML (no default specified) this must be done with a YAML tag.  For instance, in the following example the first particle in the list specified as a tracer particle initialized using a BoxInitializer.
@@ -52,6 +31,29 @@ particles:
       formula: "t + x + y"
 
 ```
+
+## Running ABLATE from the Command Line
+If you built ABLATE using the command line you can run ABLATE using either the debug or release builds.
+    
+    ```bash
+    # navigate to either the debug or release directory of ABLATE
+    ./ablate --input /path/to/the/inputfile.yaml
+
+    # similarly, ABLATE can be run using mpi
+    mpirun -n 3 ./abalte --input /path/to/the/inputfile.yaml
+    ```
+
+Other available command line arguments are listed in [Parser Command Line Arguments](#parser-command-line-arguments).
+
+Parameters within the yaml file can be overwritten using the command line using the syntax ```-yaml::PATH::TO::PARAMETER updatedValue```.  For instance, the following command would update the Npb parameter in the above Yaml example ```-yaml::particles::initializer::arguments::Npb 40```.
+
+## Running ABLATE from CLion
+1. If you are new to CLion it is recommend that you read through the [CLion Quick Start Guide](https://www.jetbrains.com/help/clion/clion-quick-start-guide.html).
+1. Select the ablate configuration from the configuration drop down.
+    ![clion ablate configuration selection](assets/clion_ablate_configuration.png)
+1. Under the same menu select "Edit Configurations..." and enter the input file argument as shown.  Other available command line arguments are listed in [Parser Command Line Arguments](#parser-command-line-arguments).
+    ![clion ablate configuration setup](assets/clion_ablate_configuration_setup.png)
+1. Run or Debug ABLATE using the icons in the toolbar or under the Run menu.
 
 ## Parser Command Line Arguments
 

--- a/docs/content/parser/RunningSimulations.md
+++ b/docs/content/parser/RunningSimulations.md
@@ -40,7 +40,7 @@ If you built ABLATE using the command line you can run ABLATE using either the d
     ./ablate --input /path/to/the/inputfile.yaml
 
     # similarly, ABLATE can be run using mpi
-    mpirun -n 3 ./abalte --input /path/to/the/inputfile.yaml
+    mpirun -n 3 ./ablate --input /path/to/the/inputfile.yaml
     ```
 
 Other available command line arguments are listed in [Parser Command Line Arguments](#parser-command-line-arguments).

--- a/docs/content/parser/index.md
+++ b/docs/content/parser/index.md
@@ -5,3 +5,4 @@ nav_order: 7
 has_children: true
 ---
 # Yaml Input Files
+[Example Input Files](https://github.com/UBCHREST/ablate/tree/main/tests/integrationTests/inputs)

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,9 @@
+#include <fstream>
 #include <iostream>
 #include <memory>
+#include <parameters/petscPrefixOptions.hpp>
 #include <utilities/fileUtility.hpp>
+#include <utilities/mpiError.hpp>
 #include "builder.hpp"
 #include "environment/runEnvironment.hpp"
 #include "parser/listing.h"
@@ -9,14 +12,16 @@
 
 using namespace ablate;
 
-int main(int argc, char **args) {
+const char* replacementInputPrefix = "-yaml::";
+
+int main(int argc, char** args) {
     // initialize petsc and mpi
     PetscInitialize(&argc, &args, NULL, NULL) >> checkError;
 
     // check to see if we should print version
     PetscBool printVersion = PETSC_FALSE;
     PetscOptionsGetBool(NULL, NULL, "-version", &printVersion, NULL) >> checkError;
-    if(!printVersion){
+    if (!printVersion) {
         PetscOptionsGetBool(NULL, NULL, "--version", &printVersion, NULL) >> checkError;
     }
     if (printVersion) {
@@ -45,21 +50,34 @@ int main(int argc, char **args) {
         throw std::invalid_argument("unable to locate input file: " + filePath.string());
     }
     {
+        // build options from the command line
+        auto yamlOptions = std::make_shared<ablate::parameters::PetscPrefixOptions>(replacementInputPrefix);
+
         // create the yaml parser
-        std::shared_ptr<parser::YamlParser> parser = std::make_shared<parser::YamlParser>(filePath);
+        std::shared_ptr<parser::YamlParser> parser = std::make_shared<parser::YamlParser>(filePath, true, yamlOptions);
 
         // setup the monitor
         auto setupEnvironmentParameters = parser->GetByName<ablate::parameters::Parameters>("environment");
         environment::RunEnvironment::Setup(*setupEnvironmentParameters, filePath);
+
+        // Copy over the input file
+        int rank;
+        MPI_Comm_rank(PETSC_COMM_WORLD, &rank) >> checkMpiError;
+        if (rank == 0) {
+            std::filesystem::path inputCopy = environment::RunEnvironment::Get().GetOutputDirectory() / filePath.filename();
+            std::ofstream stream(inputCopy);
+            parser->Print(stream);
+            stream.close();
+        }
 
         // run with the parser
         Builder::Run(parser);
 
         // check for unused parameters
         auto unusedValues = parser->GetUnusedValues();
-        if(!unusedValues.empty()){
+        if (!unusedValues.empty()) {
             std::cout << "WARNING: The following input parameters were not used:" << std::endl;
-            for(auto unusedValue : unusedValues){
+            for (auto unusedValue : unusedValues) {
                 std::cout << unusedValue << std::endl;
             }
         }

--- a/tests/ablateLibrary/environment/runEnvironmentTests.cpp
+++ b/tests/ablateLibrary/environment/runEnvironmentTests.cpp
@@ -49,8 +49,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldSetupDefaultEnviroment) {
     ASSERT_TRUE(runEnvironment.GetOutputDirectory().filename().string().rfind(uniqueTitle, 0) == 0) << "the output directory should start with the title";
     ASSERT_EQ(tempInputFile.parent_path(), runEnvironment.GetOutputDirectory().parent_path()) << "the output directory should be next to the input file";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_TRUE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should contain a copy of the input file";
-    ASSERT_EQ(std::filesystem::file_size(runEnvironment.GetOutputDirectory() / "tempFile.yaml"), std::filesystem::file_size(tempInputFile)) << "the copied input file should be the same size";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -71,8 +69,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldNotTagOutputDirectory) {
     ASSERT_EQ(runEnvironment.GetOutputDirectory().filename().string(), uniqueTitle) << "the output directory should be the title";
     ASSERT_EQ(tempInputFile.parent_path(), runEnvironment.GetOutputDirectory().parent_path()) << "the output directory should be next to the input file";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_TRUE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should contain a copy of the input file";
-    ASSERT_EQ(std::filesystem::file_size(runEnvironment.GetOutputDirectory() / "tempFile.yaml"), std::filesystem::file_size(tempInputFile)) << "the copied input file should be the same size";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -95,8 +91,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldUseAndTagSpecifiedOutputDirectory) {
     ASSERT_TRUE(runEnvironment.GetOutputDirectory().filename().string().rfind(outputDirectory.filename().string(), 0) == 0) << "the output directory should start with specified_output_dir_";
     ASSERT_EQ(outputDirectory.parent_path(), runEnvironment.GetOutputDirectory().parent_path()) << "the output directory should be in the specified location";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_TRUE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should contain a copy of the input file";
-    ASSERT_EQ(std::filesystem::file_size(runEnvironment.GetOutputDirectory() / "tempFile.yaml"), std::filesystem::file_size(tempInputFile)) << "the copied input file should be the same size";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -118,8 +112,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldUseWithoutTaggingSpecifiedOutputDirector
     // assert
     ASSERT_EQ(outputDirectory, runEnvironment.GetOutputDirectory()) << "the output directory should the one specified";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_TRUE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should contain a copy of the input file";
-    ASSERT_EQ(std::filesystem::file_size(runEnvironment.GetOutputDirectory() / "tempFile.yaml"), std::filesystem::file_size(tempInputFile)) << "the copied input file should be the same size";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -140,7 +132,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldSetupDefaultWithoutInputFile) {
     ASSERT_TRUE(runEnvironment.GetOutputDirectory().filename().string().rfind(uniqueTitle, 0) == 0) << "the output directory should start with the title";
     ASSERT_EQ(std::filesystem::current_path(), runEnvironment.GetOutputDirectory().parent_path()) << "the output directory should be next to the input file";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_FALSE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should not contain a copy of the input file";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -161,7 +152,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldNotTagOutputDirectoryWithoutInputFile) {
     ASSERT_EQ(runEnvironment.GetOutputDirectory().filename().string(), uniqueTitle) << "the output directory should be the title";
     ASSERT_EQ(std::filesystem::current_path(), runEnvironment.GetOutputDirectory().parent_path()) << "the output directory should be next to the input file";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_FALSE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should not contain a copy of the input file";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -184,7 +174,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldUseAndTagSpecifiedOutputDirectoryWithout
     ASSERT_TRUE(runEnvironment.GetOutputDirectory().filename().string().rfind(outputDirectory.filename().string(), 0) == 0) << "the output directory should start with specified_output_dir_";
     ASSERT_EQ(outputDirectory.parent_path(), runEnvironment.GetOutputDirectory().parent_path()) << "the output directory should be in the specified location";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_FALSE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should not contain a copy of the input file";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());
@@ -206,7 +195,6 @@ TEST_F(RunEnvironmentTestFixture, ShouldUseWithoutTaggingSpecifiedOutputDirector
     // assert
     ASSERT_EQ(outputDirectory, runEnvironment.GetOutputDirectory()) << "the output directory should the one specified";
     ASSERT_GT(runEnvironment.GetOutputDirectory().string().length(), uniqueTitle.length()) << "the output directory include additional date/time/info";
-    ASSERT_FALSE(std::filesystem::exists(runEnvironment.GetOutputDirectory() / "tempFile.yaml")) << "the output directory should not contain a copy of the input file";
 
     // cleanup
     std::filesystem::remove_all(runEnvironment.GetOutputDirectory());

--- a/tests/ablateLibrary/parameters/CMakeLists.txt
+++ b/tests/ablateLibrary/parameters/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(libraryTests
         parameterTests.cpp
         factoryParameterTests.cpp
         mockParameters.hpp
+        mapParameterTests.cpp
         )

--- a/tests/ablateLibrary/parameters/mapParameterTests.cpp
+++ b/tests/ablateLibrary/parameters/mapParameterTests.cpp
@@ -1,0 +1,24 @@
+#include "gtest/gtest.h"
+#include "parameters/mapParameters.hpp"
+
+TEST(MapParametersTests, ShouldCreateFromMap) {
+    // arrange
+    std::map<std::string, std::string> map = {{"item1", "value1"}, {"item2", "value2"}};
+
+    // act
+    ablate::parameters::MapParameters mapParameters(map);
+
+    // assert
+    ASSERT_EQ(mapParameters.GetString("item1"), "value1");
+    ASSERT_EQ(mapParameters.GetString("item2"), "value2");
+}
+
+TEST(MapParametersTests, ShouldCreateFromInitializerList) {
+    // arrange
+    // act
+    ablate::parameters::MapParameters mapParameters = {{"item1", "value1"}, {"item2", "value2"}};
+
+    // assert
+    ASSERT_EQ(mapParameters.GetString("item1"), "value1");
+    ASSERT_EQ(mapParameters.GetString("item2"), "value2");
+}

--- a/tests/ablateLibrary/parser/yamlParserTests.cpp
+++ b/tests/ablateLibrary/parser/yamlParserTests.cpp
@@ -676,7 +676,7 @@ TEST(YamlParserTests, ShouldPrintToStream) {
     ASSERT_EQ(outStream.str(), yaml.str());
 }
 
-TEST(YamlParserTests, ShouldAllowOverwrittenValues) {
+TEST(YamlParserTests, ShouldAllowOverWrittenValues) {
     // arrange
     std::stringstream yaml;
     yaml << "---" << std::endl;

--- a/tests/ablateLibrary/parser/yamlParserTests.cpp
+++ b/tests/ablateLibrary/parser/yamlParserTests.cpp
@@ -1,6 +1,7 @@
 #include <PetscTestFixture.hpp>
 #include <fstream>
 #include <memory>
+#include <parameters/mapParameters.hpp>
 #include <sstream>
 #include "environment/runEnvironment.hpp"
 #include "gtest/gtest.h"
@@ -627,7 +628,8 @@ TEST(YamlParserTests, ShouldLocateFileNextToInputFile) {
     {
         std::ofstream ofs(tempYaml);
         ofs << "---" << std::endl;
-        ofs << " fileName: tempFileNameForTesting.txt" << std::endl;
+        ofs << " mesh: " << std::endl;
+        ofs << "   fileName: tempFileNameForTesting.txt" << std::endl;
         ofs.close();
     }
 
@@ -639,9 +641,10 @@ TEST(YamlParserTests, ShouldLocateFileNextToInputFile) {
     }
 
     auto yamlParser = std::make_shared<YamlParser>(tempYaml);
+    auto yamlMeshFactory = yamlParser->GetFactory("mesh");
 
     // act
-    auto computedFilePath = yamlParser->Get(ArgumentIdentifier<std::filesystem::path>{"fileName"});
+    auto computedFilePath = yamlMeshFactory->Get(ArgumentIdentifier<std::filesystem::path>{"fileName"});
 
     // assert
     ASSERT_TRUE(std::filesystem::exists(computedFilePath));
@@ -651,6 +654,67 @@ TEST(YamlParserTests, ShouldLocateFileNextToInputFile) {
     // cleanup
     fs::remove(tmpFile);
     fs::remove(tempYaml);
+}
+
+TEST(YamlParserTests, ShouldPrintToStream) {
+    // arrange
+    std::stringstream yaml;
+    yaml << "---" << std::endl;
+    yaml << "item1: 22" << std::endl;
+    yaml << "item2:" << std::endl;
+    yaml << "  item3: 3" << std::endl;
+    yaml << "  item4: 5" << std::endl;
+
+    auto yamlParser = std::make_shared<YamlParser>(yaml.str());
+
+    std::stringstream outStream;
+
+    // act
+    yamlParser->Print(outStream);
+
+    // assert
+    ASSERT_EQ(outStream.str(), yaml.str());
+}
+
+TEST(YamlParserTests, ShouldAllowOverwrittenValues) {
+    // arrange
+    std::stringstream yaml;
+    yaml << "---" << std::endl;
+    yaml << "item1: 22" << std::endl;
+    yaml << "item2:" << std::endl;
+    yaml << "  item3: 3" << std::endl;
+    yaml << "  item4: 5" << std::endl;
+    yaml << "  item5: " << std::endl;
+    yaml << "    item6: {} " << std::endl;
+
+    auto params = std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+        {"item1", "44"},
+        {"item2::item4", "55"},
+        {"item2::item5::item6::item7", "77"},
+
+    });
+
+    // act
+    auto yamlParser = std::make_shared<YamlParser>(yaml.str(), false, params);
+
+    // assert
+    ASSERT_EQ("44", yamlParser->GetByName<std::string>("item1"));
+    ASSERT_EQ("55", yamlParser->GetFactory("item2")->GetByName<std::string>("item4"));
+    ASSERT_EQ("77", yamlParser->GetFactory("item2")->GetFactory("item5")->GetFactory("item6")->GetByName<std::string>("item7"));
+
+    // the output should be updated
+    std::stringstream yamlUpdated;
+    yamlUpdated << "---" << std::endl;
+    yamlUpdated << "item1: 44" << std::endl;
+    yamlUpdated << "item2:" << std::endl;
+    yamlUpdated << "  item3: 3" << std::endl;
+    yamlUpdated << "  item4: 55" << std::endl;
+    yamlUpdated << "  item5:" << std::endl;
+    yamlUpdated << "    item6: {item7: 77}" << std::endl;
+
+    std::stringstream outStream;
+    yamlParser->Print(outStream);
+    ASSERT_EQ(outStream.str(), yamlUpdated.str());
 }
 
 class YamlParserTestsPetscTestFixture : public testingResources::PetscTestFixture {};

--- a/tests/integrationTests/outputs/compressibleCouetteFlow.txt
+++ b/tests/integrationTests/outputs/compressibleCouetteFlow.txt
@@ -41,4 +41,3 @@ Timestep: 0019 time = (.*) 	 l2_norm error:<expects> ~
 Timestep: 0020 time = (.*) 	 l2_norm error:<expects> >0.002
 	 euler: \[(.*), (.*), (.*), (.*)\]<expects> <0.01 <1000 <28 <1
 ResultFiles:
-compressibleCouetteFlow.yaml

--- a/tests/integrationTests/outputs/compressibleFlowVortex.txt
+++ b/tests/integrationTests/outputs/compressibleFlowVortex.txt
@@ -26,6 +26,5 @@ Timestep: 0023 time = (.*) dt = (.*)<expects> ~ ~
 Timestep: 0024 time = (.*) dt = (.*)<expects> ~ ~
 Timestep: 0025 time = (.*) dt = (.*)<expects> ~ ~
 ResultFiles:
-compressibleFlowVortex.yaml
 vortexFlowField.hdf5
 vortexFlowField.xmf

--- a/tests/integrationTests/outputs/customCouetteCompressibleFlow.txt
+++ b/tests/integrationTests/outputs/customCouetteCompressibleFlow.txt
@@ -41,4 +41,3 @@ Timestep: 0019 time = (.*) 	 l2_norm error:<expects> ~
 Timestep: 0020 time = (.*) 	 l2_norm error:<expects> >0.002
 	 euler: \[(.*), (.*), (.*), (.*)\]<expects> <0.01 <1000 <28 <1
 ResultFiles:
-customCouetteCompressibleFlow.yaml

--- a/tests/integrationTests/outputs/incompressibleFlow.txt
+++ b/tests/integrationTests/outputs/incompressibleFlow.txt
@@ -30,4 +30,3 @@ Timestep: 0028 time = 2.8      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <0.006
 Timestep: 0029 time = 2.9      	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <0.006 <2 <.3
 Timestep: 0030 time = 3        	 L_2 Error: \[(.*), (.*), (.*)\]<expects> <0.006 <2 <.3
 ResultFiles:
-incompressibleFlow.yaml

--- a/tests/integrationTests/outputs/simpleReactingFlow.txt
+++ b/tests/integrationTests/outputs/simpleReactingFlow.txt
@@ -26,6 +26,5 @@ Timestep: 0023 time = 2.3e-05  dt = 1e-06
 Timestep: 0024 time = 2.4e-05  dt = 1e-06
 Timestep: 0025 time = 2.5e-05  dt = 1e-06
 ResultFiles:
-simpleReactingFlow.yaml
 vortexFlowField.hdf5
 vortexFlowField.xmf

--- a/tests/integrationTests/outputs/tracerParticles2DHDF5Monitor.txt
+++ b/tests/integrationTests/outputs/tracerParticles2DHDF5Monitor.txt
@@ -19,4 +19,3 @@ flowTracerParticles.hdf5
 flowTracerParticles.xmf
 theFlowField.hdf5
 theFlowField.xmf
-tracerParticles2DHDF5Monitor.yaml

--- a/tests/integrationTests/outputs/tracerParticles3D.txt
+++ b/tests/integrationTests/outputs/tracerParticles3D.txt
@@ -9,4 +9,3 @@ particles.hdf5
 particles.xmf
 theFlowField.hdf5
 theFlowField.xmf
-tracerParticles3D.yaml


### PR DESCRIPTION
This PR allows for values in the yaml to be overwritten on the command line for ABLATE.  For instance to change the environment title or number of time steps you would:
```bash
-yaml::environment::title blue -yaml::timestepper::arguments::ts_max_steps 10
```

This closes #98 