### PR TITLE
Adds ignition delay monitors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_get_variable(PETSC_CXX_COMPILER PETSc cxxcompiler)
 set(CMAKE_CXX_COMPILER ${PETSC_CXX_COMPILER})
 
 # Set the project details
-project(ablateLibrary VERSION 0.4.18)
+project(ablateLibrary VERSION 0.4.19)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED PETSc)

--- a/ablateCore/CMakeLists.txt
+++ b/ablateCore/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(ablateCore "")
 # Include PETSc and MPI
 target_include_directories(ablateCore PUBLIC ${PETSc_INCLUDE_DIRS})
 target_link_libraries(ablateCore PUBLIC ${PETSc_LIBRARIES})
-target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS} /opt/homebrew/Cellar/gcc/11.1.0_1/lib/gcc/11)
+target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS})
 
 # Allow public access to the header files in the directory
 target_include_directories(ablateCore PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/ablateCore/CMakeLists.txt
+++ b/ablateCore/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(ablateCore "")
 # Include PETSc and MPI
 target_include_directories(ablateCore PUBLIC ${PETSc_INCLUDE_DIRS})
 target_link_libraries(ablateCore PUBLIC ${PETSc_LIBRARIES})
-target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS})
+target_link_directories(ablateCore PUBLIC ${PETSc_LIBRARY_DIRS} /opt/homebrew/Cellar/gcc/11.1.0_1/lib/gcc/11)
 
 # Allow public access to the header files in the directory
 target_include_directories(ablateCore PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/ablateLibrary/flow/flow.cpp
+++ b/ablateLibrary/flow/flow.cpp
@@ -412,3 +412,12 @@ void ablate::flow::Flow::View(PetscViewer viewer, PetscInt steps, PetscReal time
         DMRestoreGlobalVector(dm->GetDomain(), &exactVec) >> checkError;
     }
 }
+
+const ablate::flow::FlowFieldDescriptor& ablate::flow::Flow::GetFieldDescriptor(const std::string& fieldName) const {
+    for (const auto& descriptor : flowFieldDescriptors) {
+        if (descriptor.fieldName == fieldName) {
+            return descriptor;
+        }
+    }
+    throw std::invalid_argument("Cannot locate field descriptor for " + fieldName);
+}

--- a/ablateLibrary/flow/flow.hpp
+++ b/ablateLibrary/flow/flow.hpp
@@ -124,6 +124,8 @@ class Flow : public solve::Solvable, public monitors::Viewable {
     std::optional<int> GetFieldId(const std::string& fieldName) const;
 
     std::optional<int> GetAuxFieldId(const std::string& fieldName) const;
+
+    const FlowFieldDescriptor& GetFieldDescriptor(const std::string& fieldName) const;
 };
 }  // namespace ablate::flow
 

--- a/ablateLibrary/flow/processes/tChemReactions.cpp
+++ b/ablateLibrary/flow/processes/tChemReactions.cpp
@@ -15,10 +15,10 @@
 #error TChem is required for this example.  Reconfigure PETSc using --download-tchem.
 #endif
 
-ablate::flow::processes::TChemReactions::TChemReactions(std::shared_ptr<eos::TChem> eosIn)
+ablate::flow::processes::TChemReactions::TChemReactions(std::shared_ptr<eos::EOS> eosIn)
     : fieldDm(nullptr),
       sourceVec(nullptr),
-      eos(eosIn),
+      eos(std::dynamic_pointer_cast<eos::TChem>(eosIn)),
       numberSpecies(eosIn->GetSpecies().size()),
       ts(nullptr),
       pointData(nullptr),
@@ -26,6 +26,11 @@ ablate::flow::processes::TChemReactions::TChemReactions(std::shared_ptr<eos::TCh
       tchemScratch(nullptr),
       jacobianScratch(nullptr),
       rows(nullptr) {
+    // make sure that the eos is set
+    if (!std::dynamic_pointer_cast<eos::TChem>(eosIn)) {
+        throw std::invalid_argument("ablate::flow::processes::TChemReactions::TChemReactions only accepts EOS of type eos::TChem");
+    }
+
     // size up the scratch variables
     PetscMalloc3(numberSpecies + 1, &tchemScratch, PetscSqr(numberSpecies + 1), &jacobianScratch, numberSpecies, &rows) >> checkError;
     // The rows will not change, so set them once
@@ -452,4 +457,4 @@ PetscErrorCode ablate::flow::processes::TChemReactions::AddChemistrySourceToFlow
 }
 
 #include "parser/registrar.hpp"
-REGISTER(ablate::flow::processes::FlowProcess, ablate::flow::processes::TChemReactions, "reactions using the TChem v1 library", OPT(eos::TChem, "eos", "the tChem v1 eos"));
+REGISTER(ablate::flow::processes::FlowProcess, ablate::flow::processes::TChemReactions, "reactions using the TChem v1 library", ARG(eos::EOS, "eos", "the tChem v1 eos"));

--- a/ablateLibrary/flow/processes/tChemReactions.hpp
+++ b/ablateLibrary/flow/processes/tChemReactions.hpp
@@ -57,7 +57,7 @@ class TChemReactions : public FlowProcess {
     static PetscErrorCode AddChemistrySourceToFlow(DM dm, PetscReal time, Vec locX, Vec fVec, void *ctx);
 
    public:
-    explicit TChemReactions(std::shared_ptr<eos::TChem> eos);
+    explicit TChemReactions(std::shared_ptr<eos::EOS> eos);
     ~TChemReactions() override;
     /**
      * public function to link this process with the flow

--- a/ablateLibrary/monitors/CMakeLists.txt
+++ b/ablateLibrary/monitors/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(ablateLibrary
         timeStepMonitor.cpp
         ignitionDelayPeakYi.hpp
         ignitionDelayPeakYi.cpp
+        ignitionDelayTemperature.hpp
+        ignitionDelayTemperature.cpp
         )
 
 add_subdirectory(logs)

--- a/ablateLibrary/monitors/CMakeLists.txt
+++ b/ablateLibrary/monitors/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(ablateLibrary
         solutionErrorMonitor.cpp
         timeStepMonitor.hpp
         timeStepMonitor.cpp
+        ignitionDelayPeakYi.hpp
+        ignitionDelayPeakYi.cpp
         )
 
 add_subdirectory(logs)

--- a/ablateLibrary/monitors/ignitionDelayPeakYi.cpp
+++ b/ablateLibrary/monitors/ignitionDelayPeakYi.cpp
@@ -19,7 +19,7 @@ ablate::monitors::IgnitionDelayPeakYi::~IgnitionDelayPeakYi() {
         }
     }
 
-    log->Printf("Computed Ignition Delay (%s): %f\n", species.c_str(), timeHistory[loc]);
+    log->Printf("Computed Ignition Delay (%s): %g\n", species.c_str(), timeHistory[loc]);
 }
 
 void ablate::monitors::IgnitionDelayPeakYi::Register(std::shared_ptr<Monitorable> monitorableObject) {
@@ -131,7 +131,7 @@ PetscErrorCode ablate::monitors::IgnitionDelayPeakYi::MonitorIgnition(TS ts, Pet
     monitor->yiHistory.push_back(yi);
 
     if (monitor->historyLog) {
-        monitor->historyLog->Printf("%d Time: %f Yi: %f\n", step, crtime, yi);
+        monitor->historyLog->Printf("%d Time: %g Yi: %f\n", step, crtime, yi);
     }
 
     ierr = VecRestoreArrayRead(u, &uArray);

--- a/ablateLibrary/monitors/ignitionDelayPeakYi.cpp
+++ b/ablateLibrary/monitors/ignitionDelayPeakYi.cpp
@@ -1,0 +1,146 @@
+#include "ignitionDelayPeakYi.hpp"
+#include <flow/processes/eulerAdvection.hpp>
+#include <utilities/mpiError.hpp>
+#include <utilities/petscError.hpp>
+#include "flow/fvFlow.hpp"
+#include "monitors/logs/stdOut.hpp"
+
+ablate::monitors::IgnitionDelayPeakYi::IgnitionDelayPeakYi(std::string species, std::vector<double> location, std::shared_ptr<logs::Log> logIn, std::shared_ptr<logs::Log> historyLogIn)
+    : log(logIn ? logIn : std::make_shared<logs::StdOut>()), historyLog(historyLogIn), species(species), location(location) {}
+
+ablate::monitors::IgnitionDelayPeakYi::~IgnitionDelayPeakYi() {
+    // compute the time at the maximum yi
+    std::size_t loc = 0;
+    double maxValue = 0.0;
+    for (std::size_t i = 0; i < yiHistory.size(); i++) {
+        if (yiHistory[i] > maxValue) {
+            maxValue = yiHistory[i];
+            loc = i;
+        }
+    }
+
+    log->Printf("Computed Ignition Delay: %f\n", timeHistory[loc]);
+}
+
+void ablate::monitors::IgnitionDelayPeakYi::Register(std::shared_ptr<Monitorable> monitorableObject) {
+    // this probe will only work with fV flow with a single mpi rank for now.  It should be replaced with DMInterpolationEvaluate
+    auto flow = std::dynamic_pointer_cast<ablate::flow::FVFlow>(monitorableObject);
+    if (!flow) {
+        throw std::invalid_argument("The IgnitionDelay monitor can only be used with ablate::flow::FVFlow");
+    }
+
+    // check the size
+    int size;
+    MPI_Comm_size(PetscObjectComm((PetscObject)flow->GetDM()), &size) >> checkMpiError;
+    if (size != 1) {
+        throw std::runtime_error("The IgnitionDelay monitor only works with a single mpi rank");
+    }
+
+    // determine the component offset
+    auto eulerIdValue = flow->GetFieldId("euler");
+    if (eulerIdValue) {
+        eulerId = eulerIdValue.value();
+    } else {
+        throw std::invalid_argument("The IgnitionDelay monitor expects to find euler in the ablate::flow::FVFlow");
+    }
+
+    auto densityYiIdValue = flow->GetFieldId("densityYi");
+    if (densityYiIdValue) {
+        yiId = densityYiIdValue.value();
+    } else {
+        throw std::invalid_argument("The IgnitionDelay monitor expects to find densityYi in the ablate::flow::FVFlow");
+    }
+
+    const auto& speciesList = flow->GetFieldDescriptor("densityYi").componentNames;
+    yiOffset = -1;
+    for (std::size_t sp = 0; sp < speciesList.size(); sp++) {
+        if (speciesList[sp] == species) {
+            yiOffset = sp;
+        }
+    }
+    if (yiOffset < 0) {
+        throw std::invalid_argument("The IgnitionDelay monitor cannot find the " + species + " species");
+    }
+
+    // Locate the closest cell
+    PetscReal distance = PETSC_MAX_REAL;
+
+    // Get the cell start and end for the fv cells
+    PetscInt cellStart, cellEnd;
+    DMPlexGetHeightStratum(flow->GetDM(), 0, &cellStart, &cellEnd) >> checkError;
+
+    // Extract the cell geometry, and the dm that holds the information
+    Vec cellGeomVec;
+    DM dmCell;
+    const PetscScalar* cellGeomArray;
+    DMPlexGetGeometryFVM(flow->GetDM(), NULL, &cellGeomVec, NULL) >> checkError;
+    VecGetDM(cellGeomVec, &dmCell) >> checkError;
+    VecGetArrayRead(cellGeomVec, &cellGeomArray) >> checkError;
+
+    for (PetscInt c = cellStart; c < cellEnd; ++c) {
+        PetscFVCellGeom* cellGeom;
+        DMPlexPointLocalRead(dmCell, c, cellGeomArray, &cellGeom) >> checkError;
+
+        PetscReal dis = 0.0;
+        for (std::size_t d = 0; d < location.size(); d++) {
+            dis += PetscSqr(cellGeom->centroid[d] - location[d]);
+        }
+        dis = PetscSqrtReal(dis);
+        if (dis < distance) {
+            cellOfInterest = c;
+            distance = dis;
+        }
+    }
+    VecRestoreArrayRead(cellGeomVec, &cellGeomArray) >> checkError;
+
+    // init the log(s)
+    log->Initialize(PetscObjectComm((PetscObject)flow->GetDM()));
+    if (historyLog) {
+        historyLog->Initialize(PetscObjectComm((PetscObject)flow->GetDM()));
+    }
+}
+
+PetscErrorCode ablate::monitors::IgnitionDelayPeakYi::MonitorIgnition(TS ts, PetscInt step, PetscReal crtime, Vec u, void* ctx) {
+    PetscFunctionBeginUser;
+    PetscErrorCode ierr;
+    DM dm;
+    PetscDS ds;
+    ierr = TSGetDM(ts, &dm);
+    CHKERRQ(ierr);
+    ierr = DMGetDS(dm, &ds);
+    CHKERRQ(ierr);
+
+    IgnitionDelayPeakYi* monitor = (IgnitionDelayPeakYi*)ctx;
+
+    // extract the gradLocalVec
+    const PetscScalar* uArray;
+    ierr = VecGetArrayRead(u, &uArray);
+    CHKERRQ(ierr);
+
+    // Get the euler and densityYi values
+    const PetscScalar* eulerValues;
+    const PetscScalar* densityYiValues;
+    ierr = DMPlexPointGlobalFieldRead(dm, monitor->cellOfInterest, monitor->eulerId, uArray, &eulerValues);
+    CHKERRQ(ierr);
+    ierr = DMPlexPointGlobalFieldRead(dm, monitor->cellOfInterest, monitor->yiId, uArray, &densityYiValues);
+    CHKERRQ(ierr);
+
+    // Store the result
+    double yi = densityYiValues[monitor->yiOffset] / eulerValues[ablate::flow::processes::EulerAdvection::RHO];
+    monitor->timeHistory.push_back(crtime);
+    monitor->yiHistory.push_back(yi);
+
+    if (monitor->historyLog) {
+        monitor->historyLog->Printf("%d Time: %f Yi: %f\n", step, crtime, yi);
+    }
+
+    ierr = VecRestoreArrayRead(u, &uArray);
+    CHKERRQ(ierr);
+    PetscFunctionReturn(0);
+}
+
+#include "parser/registrar.hpp"
+REGISTER(ablate::monitors::Monitor, ablate::monitors::IgnitionDelayPeakYi, "Compute the ignition time based upon peak mass fraction",
+         ARG(std::string, "species", "the species used to determine the peak Yi"), ARG(std::vector<double>, "location", "the monitor location"),
+         OPT(ablate::monitors::logs::Log, "log", "where to record the final ignition time (default is stdout)"),
+         OPT(ablate::monitors::logs::Log, "historyLog", "where to record the time and yi history (default is none)"));

--- a/ablateLibrary/monitors/ignitionDelayPeakYi.hpp
+++ b/ablateLibrary/monitors/ignitionDelayPeakYi.hpp
@@ -1,0 +1,40 @@
+#ifndef ABLATELIBRARY_IGNITIONDELAYPEAKYI_HPP
+#define ABLATELIBRARY_IGNITIONDELAYPEAKYI_HPP
+
+#include <monitors/logs/log.hpp>
+#include "monitor.hpp"
+
+namespace ablate::monitors {
+
+/**
+ * The ignition delay monitor logs the mass fraction of the specified species and computes the ignition delay from its peak value.
+ */
+
+class IgnitionDelayPeakYi : public Monitor {
+   private:
+    static PetscErrorCode MonitorIgnition(TS ts, PetscInt step, PetscReal crtime, Vec u, void *ctx);
+    const std::shared_ptr<logs::Log> log;
+    const std::shared_ptr<logs::Log> historyLog;
+
+    const std::string species;
+    const std::vector<double> location;
+
+    // The offset for the density and mass fractions in the solution array
+    PetscInt eulerId;
+    PetscInt yiId;
+    PetscInt yiOffset;
+    PetscInt cellOfInterest;
+
+    std::vector<double> timeHistory;
+    std::vector<double> yiHistory;
+
+   public:
+    explicit IgnitionDelayPeakYi(std::string species, std::vector<double> location, std::shared_ptr<logs::Log> log = {}, std::shared_ptr<logs::Log> historyLogIn = {});
+    ~IgnitionDelayPeakYi() override;
+
+    void Register(std::shared_ptr<Monitorable>) override;
+    PetscMonitorFunction GetPetscFunction() override { return MonitorIgnition; }
+};
+
+}  // namespace ablate::monitors
+#endif  // ABLATELIBRARY_IGNITIONDELAYPEAKYI_HPP

--- a/ablateLibrary/monitors/ignitionDelayPeakYi.hpp
+++ b/ablateLibrary/monitors/ignitionDelayPeakYi.hpp
@@ -9,7 +9,6 @@ namespace ablate::monitors {
 /**
  * The ignition delay monitor logs the mass fraction of the specified species and computes the ignition delay from its peak value.
  */
-
 class IgnitionDelayPeakYi : public Monitor {
    private:
     static PetscErrorCode MonitorIgnition(TS ts, PetscInt step, PetscReal crtime, Vec u, void *ctx);

--- a/ablateLibrary/monitors/ignitionDelayTemperature.cpp
+++ b/ablateLibrary/monitors/ignitionDelayTemperature.cpp
@@ -12,7 +12,7 @@ ablate::monitors::IgnitionDelayTemperature::IgnitionDelayTemperature(std::shared
 ablate::monitors::IgnitionDelayTemperature::~IgnitionDelayTemperature() {
     for (std::size_t i = 0; i < temperatureHistory.size(); i++) {
         if (temperatureHistory[i] > thresholdTemperature) {
-            log->Printf("Computed Ignition Delay (Temperature): %f\n", timeHistory[i]);
+            log->Printf("Computed Ignition Delay (Temperature): %g\n", timeHistory[i]);
             return;
         }
     }
@@ -129,7 +129,7 @@ PetscErrorCode ablate::monitors::IgnitionDelayTemperature::MonitorIgnition(TS ts
     monitor->temperatureHistory.push_back(T);
 
     if (monitor->historyLog) {
-        monitor->historyLog->Printf("%d Time: %f Temperature: %f\n", step, crtime, T);
+        monitor->historyLog->Printf("%d Time: %g Temperature: %f\n", step, crtime, T);
     }
 
     ierr = VecRestoreArrayRead(u, &uArray);

--- a/ablateLibrary/monitors/ignitionDelayTemperature.cpp
+++ b/ablateLibrary/monitors/ignitionDelayTemperature.cpp
@@ -47,36 +47,30 @@ void ablate::monitors::IgnitionDelayTemperature::Register(std::shared_ptr<Monito
         throw std::invalid_argument("The IgnitionDelay monitor expects to find densityYi in the ablate::flow::FVFlow");
     }
 
-    // Locate the closest cell
-    PetscReal distance = PETSC_MAX_REAL;
+    // Convert the location to a vec
+    Vec locVec;
+    VecCreateSeqWithArray((PetscObjectComm((PetscObject)flow->GetDM())), location.size(), location.size(), &location[0], &locVec) >> checkError;
 
-    // Get the cell start and end for the fv cells
-    PetscInt cellStart, cellEnd;
-    DMPlexGetHeightStratum(flow->GetDM(), 0, &cellStart, &cellEnd) >> checkError;
+    // Get all points still in this mesh
+    PetscSF cellSF = NULL;
+    DMLocatePoints(flow->GetDM(), locVec, DM_POINTLOCATION_NONE, &cellSF) >> checkError;
+    const PetscSFNode* cells;
+    PetscInt numberFound;
+    PetscInt rank;
+    MPI_Comm_rank((PetscObjectComm((PetscObject)flow->GetDM())), &rank) >> checkMpiError;
 
-    // Extract the cell geometry, and the dm that holds the information
-    Vec cellGeomVec;
-    DM dmCell;
-    const PetscScalar* cellGeomArray;
-    DMPlexGetGeometryFVM(flow->GetDM(), NULL, &cellGeomVec, NULL) >> checkError;
-    VecGetDM(cellGeomVec, &dmCell) >> checkError;
-    VecGetArrayRead(cellGeomVec, &cellGeomArray) >> checkError;
-
-    for (PetscInt c = cellStart; c < cellEnd; ++c) {
-        PetscFVCellGeom* cellGeom;
-        DMPlexPointLocalRead(dmCell, c, cellGeomArray, &cellGeom) >> checkError;
-
-        PetscReal dis = 0.0;
-        for (std::size_t d = 0; d < location.size(); d++) {
-            dis += PetscSqr(cellGeom->centroid[d] - location[d]);
+    PetscSFGetGraph(cellSF, NULL, &numberFound, NULL, &cells) >> checkError;
+    if (numberFound == 1) {
+        if (cells[0].rank == rank) {
+            cellOfInterest = cells[0].index;
         }
-        dis = PetscSqrtReal(dis);
-        if (dis < distance) {
-            cellOfInterest = c;
-            distance = dis;
-        }
+    } else {
+        throw std::runtime_error("Cannot locate cell for location in IgnitionDelayPeakYi");
     }
-    VecRestoreArrayRead(cellGeomVec, &cellGeomArray) >> checkError;
+
+    // restore
+    PetscSFDestroy(&cellSF) >> checkError;
+    VecDestroy(&locVec) >> checkError;
 
     // init the log(s)
     log->Initialize(PetscObjectComm((PetscObject)flow->GetDM()));

--- a/ablateLibrary/monitors/ignitionDelayTemperature.hpp
+++ b/ablateLibrary/monitors/ignitionDelayTemperature.hpp
@@ -1,0 +1,42 @@
+#ifndef ABLATELIBRARY_IGNITIONDELAYTEMPERATURE_HPP
+#define ABLATELIBRARY_IGNITIONDELAYTEMPERATURE_HPP
+
+#include <monitors/logs/log.hpp>
+#include "eos/eos.hpp"
+#include "monitor.hpp"
+
+namespace ablate::monitors {
+
+/**
+ * The ignition delay monitor logs the temperature computes the ignition delay from it.
+ */
+class IgnitionDelayTemperature : public Monitor {
+    static PetscErrorCode MonitorIgnition(TS ts, PetscInt step, PetscReal crtime, Vec u, void *ctx);
+
+    // store the eos inorder to compute temperature
+    const std::shared_ptr<eos::EOS> eos;
+    const double thresholdTemperature;
+    const std::shared_ptr<logs::Log> log;
+    const std::shared_ptr<logs::Log> historyLog;
+
+    const std::string species;
+    const std::vector<double> location;
+
+    // The offset for the euler and mass fractions in the solution array
+    PetscInt eulerId;
+    PetscInt yiId;
+    PetscInt cellOfInterest;
+
+    std::vector<double> timeHistory;
+    std::vector<double> temperatureHistory;
+
+   public:
+    explicit IgnitionDelayTemperature(std::shared_ptr<eos::EOS>, std::vector<double> location, double thresholdTemperature, std::shared_ptr<logs::Log> log = {},
+                                      std::shared_ptr<logs::Log> historyLog = {});
+    ~IgnitionDelayTemperature() override;
+
+    void Register(std::shared_ptr<Monitorable>) override;
+    PetscMonitorFunction GetPetscFunction() override { return MonitorIgnition; }
+};
+}  // namespace ablate::monitors
+#endif  // ABLATELIBRARY_IGNITIONDELAYTEMPERATURE_HPP

--- a/tests/integrationTests/inputs/ignitionDelayGriMech.yaml
+++ b/tests/integrationTests/inputs/ignitionDelayGriMech.yaml
@@ -1,0 +1,63 @@
+---
+environment:
+  title: _ignitionDelayGriMech
+  tagDirectory: false
+arguments: 
+  petsclimiter_type: none
+timestepper:
+  name: theMainTimeStepper
+  arguments:
+    ts_type: rk
+    ts_max_time: 0.1
+    ts_dt: 1E-4
+flow: !ablate::flow::FVFlow
+  name: reactingFlowODE
+  mesh: !ablate::mesh::BoxMesh
+    name: simpleBoxField
+    faces: [ 1, 1 ]
+    lower: [ 0, 0]
+    upper: [1, 1]
+    options:
+      dm_refine: 0
+  options: {}
+  parameters: {}
+  fields:
+    - fieldName: euler
+      fieldPrefix: euler
+      components: 4
+      fieldType: FV
+    - fieldName: densityYi
+      fieldPrefix: densityYi
+      components: 53
+      fieldType: FV
+      componentNames: ['H2', 'H', 'O', 'O2', 'OH', 'H2O', 'HO2', 'H2O2', 'C', 'CH', 'CH2', 'CH2(S)', 'CH3', 'CH4', 'CO', 'CO2', 'HCO', 'CH2O', 'CH2OH', 'CH3O', 'CH3OH', 'C2H', 'C2H2', 'C2H3', 'C2H4', 'C2H5', 'C2H6', 'HCCO', 'CH2CO', 'HCCOH', 'N', 'NH', 'NH2', 'NH3', 'NNH', 'NO', 'NO2', 'N2O', 'HNO', 'CN', 'HCN', 'H2CN', 'HCNN', 'HCNO', 'HOCN', 'HNCO', 'NCO', 'N2', 'AR', 'C3H7', 'C3H8', 'CH2CHO', 'CH3CHO']
+    - fieldName: vel
+      fieldPrefix: vel
+      components: 2
+      fieldType: FV
+      solutionField: false
+  processes:
+    - !ablate::flow::processes::TChemReactions
+      eos: !ablate::eos::TChem
+        mechFile: inputs/grimech30.dat
+        thermoFile: inputs/thermo30.dat
+  initialization:
+    - fieldName: "euler" #for euler all components are in a single field
+      solutionField:
+        formula: >-
+          0.2806317906177915,
+          212565.75335864403,
+          0.0,
+          0.0
+    - fieldName: "densityYi" 
+      solutionField: 
+        formula: 0.        ,0.        ,0.        ,0.06177863,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.01548713,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.        ,0.20336603,0.        ,0.        ,0.        ,0.        ,0.      
+  boundaryConditions: []
+  monitors:
+    - !ablate::monitors::IgnitionDelayPeakYi
+      species: OH
+      location: [0.5, 0.5]
+      log: !ablate::monitors::logs::StdOut {}
+      historyLog: !ablate::monitors::logs::CsvLog
+        name: ignitionDelayPeakYi.csv
+

--- a/tests/integrationTests/inputs/ignitionDelayGriMech.yaml
+++ b/tests/integrationTests/inputs/ignitionDelayGriMech.yaml
@@ -60,4 +60,13 @@ flow: !ablate::flow::FVFlow
       log: !ablate::monitors::logs::StdOut {}
       historyLog: !ablate::monitors::logs::CsvLog
         name: ignitionDelayPeakYi.csv
+    - !ablate::monitors::IgnitionDelayTemperature
+      eos: !ablate::eos::TChem
+        mechFile: inputs/grimech30.dat
+        thermoFile: inputs/thermo30.dat
+      location: [0.5, 0.5]
+      thresholdTemperature: 1500
+      log: !ablate::monitors::logs::StdOut {}
+      historyLog: !ablate::monitors::logs::CsvLog
+        name: ignitionDelayTemperature.csv
 

--- a/tests/integrationTests/inputs/ignitionDelayGriMech.yaml
+++ b/tests/integrationTests/inputs/ignitionDelayGriMech.yaml
@@ -66,7 +66,6 @@ flow: !ablate::flow::FVFlow
         thermoFile: inputs/thermo30.dat
       location: [0.5, 0.5]
       thresholdTemperature: 1500
-      log: !ablate::monitors::logs::StdOut {}
-      historyLog: !ablate::monitors::logs::CsvLog
+      log: !ablate::monitors::logs::CsvLog
         name: ignitionDelayTemperature.csv
 

--- a/tests/integrationTests/outputs/ignitionDelayGriMech.txt
+++ b/tests/integrationTests/outputs/ignitionDelayGriMech.txt
@@ -1,6 +1,6 @@
 SUCCESS
 SUCCESS
-Computed Ignition Delay \(OH\): (.*)<expects> =0.042325
+Computed Ignition Delay \(OH\): (.*)<expects> <0.05
 ResultFiles:
 ignitionDelayPeakYi.csv
 ignitionDelayTemperature.csv

--- a/tests/integrationTests/outputs/ignitionDelayGriMech.txt
+++ b/tests/integrationTests/outputs/ignitionDelayGriMech.txt
@@ -1,7 +1,6 @@
 SUCCESS
 SUCCESS
-Computed Ignition Delay \(Temperature\): (.*)<expects> <0.05
-Computed Ignition Delay \(OH\): (.*)<expects> <0.05
+Computed Ignition Delay \(OH\): (.*)<expects> =0.042325
 ResultFiles:
 ignitionDelayPeakYi.csv
 ignitionDelayTemperature.csv

--- a/tests/integrationTests/outputs/ignitionDelayGriMech.txt
+++ b/tests/integrationTests/outputs/ignitionDelayGriMech.txt
@@ -1,0 +1,4 @@
+SUCCESS
+Computed Ignition Delay: (.*)<expects> =0.042325
+ResultFiles:
+ignitionDelayPeakYi.csv

--- a/tests/integrationTests/outputs/ignitionDelayGriMech.txt
+++ b/tests/integrationTests/outputs/ignitionDelayGriMech.txt
@@ -1,7 +1,7 @@
 SUCCESS
 SUCCESS
-Computed Ignition Delay \(Temperature\): (.*)<expects> =0.042289
-Computed Ignition Delay \(OH\): (.*)<expects> =0.042325
+Computed Ignition Delay \(Temperature\): (.*)<expects> <0.05
+Computed Ignition Delay \(OH\): (.*)<expects> <0.05
 ResultFiles:
 ignitionDelayPeakYi.csv
 ignitionDelayTemperature.csv

--- a/tests/integrationTests/outputs/ignitionDelayGriMech.txt
+++ b/tests/integrationTests/outputs/ignitionDelayGriMech.txt
@@ -1,4 +1,7 @@
 SUCCESS
-Computed Ignition Delay: (.*)<expects> =0.042325
+SUCCESS
+Computed Ignition Delay \(Temperature\): (.*)<expects> =0.042289
+Computed Ignition Delay \(OH\): (.*)<expects> =0.042325
 ResultFiles:
 ignitionDelayPeakYi.csv
+ignitionDelayTemperature.csv

--- a/tests/integrationTests/tests.cpp
+++ b/tests/integrationTests/tests.cpp
@@ -75,5 +75,6 @@ INSTANTIATE_TEST_SUITE_P(
                     (MpiTestParameter){.testName = "inputs/tracerParticles3D.yaml", .nproc = 1, .expectedOutputFile = "outputs/tracerParticles3D.txt", .arguments = ""},
                     (MpiTestParameter){.testName = "inputs/compressibleFlowVortex.yaml", .nproc = 1, .expectedOutputFile = "outputs/compressibleFlowVortex.txt", .arguments = ""},
                     (MpiTestParameter){.testName = "inputs/customCouetteCompressibleFlow.yaml", .nproc = 1, .expectedOutputFile = "outputs/customCouetteCompressibleFlow.txt", .arguments = ""},
-                    (MpiTestParameter){.testName = "inputs/simpleReactingFlow.yaml", .nproc = 1, .expectedOutputFile = "outputs/simpleReactingFlow.txt", .arguments = ""}),
+                    (MpiTestParameter){.testName = "inputs/simpleReactingFlow.yaml", .nproc = 1, .expectedOutputFile = "outputs/simpleReactingFlow.txt", .arguments = ""},
+                    (MpiTestParameter){.testName = "inputs/ignitionDelayGriMech.yaml", .nproc = 1, .expectedOutputFile = "outputs/ignitionDelayGriMech.txt", .arguments = ""}),
     [](const testing::TestParamInfo<MpiTestParameter>& info) { return info.param.getTestName(); });


### PR DESCRIPTION
This PR adds ignition delay monitors and closes #93 .  Two monitors have been added, one based upon peak Yi of a species and one based upon a threshold temperature.  The tests/integrationTests/inputs/ignitionDelayGriMech.yaml is an example of a input file that uses them. 

```yaml
    - !ablate::monitors::IgnitionDelayPeakYi
      species: OH
      location: [0.5, 0.5]
      log: !ablate::monitors::logs::StdOut {}
      historyLog: !ablate::monitors::logs::CsvLog
        name: ignitionDelayPeakYi.csv
    - !ablate::monitors::IgnitionDelayTemperature
      eos: !ablate::eos::TChem
        mechFile: inputs/grimech30.dat
        thermoFile: inputs/thermo30.dat
      location: [0.5, 0.5]
      thresholdTemperature: 1500
      log: !ablate::monitors::logs::StdOut {}
      historyLog: !ablate::monitors::logs::CsvLog
        name: ignitionDelayTemperature.csv
```