### PR TITLE
add support for nested parsed math functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
-
 find_package(PkgConfig REQUIRED)
 
 # Check if a C compiler is explicitly stated
@@ -18,7 +17,7 @@ if(NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # Set the project details
-project(ablateLibrary VERSION 0.5.5)
+project(ablateLibrary VERSION 0.5.6)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED PETSc)
@@ -44,7 +43,7 @@ function(ablate_default_target_compile_options_c target)
     target_link_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wl>)
 endfunction()
 function(ablate_default_target_compile_options_cxx target)
-    target_compile_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -fvisibility=hidden -Wsuggest-override -Wno-unused-parameter>)
+    target_compile_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -Wsuggest-override -Wno-unused-parameter>)
     target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>: -Wno-missing-field-initializers>)
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,12 @@ endif()
 
 # Add required warnings for projects
 function(ablate_default_target_compile_options_c target)
-    target_compile_options(${target} PRIVATE $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -fvisibility=default -Wno-unused-parameter>)
+    target_compile_options(${target} PRIVATE $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -Wno-unused-parameter>)
     target_link_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wl>)
 endfunction()
 function(ablate_default_target_compile_options_cxx target)
-    target_compile_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -fvisibility=default -Wsuggest-override -Wno-unused-parameter>)
-    target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>: -Wno-missing-field-initializers>)
+    target_compile_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -Wsuggest-override -Wno-unused-parameter >)
+    target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>: -Wno-missing-field-initializers -Wno-maybe-uninitialized>)
 endfunction()
 
 # Load in the subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,11 @@ endif()
 
 # Add required warnings for projects
 function(ablate_default_target_compile_options_c target)
-    target_compile_options(${target} PRIVATE $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -fvisibility=hidden -Wno-unused-parameter>)
+    target_compile_options(${target} PRIVATE $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -fvisibility=default -Wno-unused-parameter>)
     target_link_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wl>)
 endfunction()
 function(ablate_default_target_compile_options_cxx target)
-    target_compile_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -Wsuggest-override -Wno-unused-parameter>)
+    target_compile_options(${target} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Werror -Wall -Wextra -Wwrite-strings -Wno-strict-aliasing -Wno-unknown-pragmas -Wsign-compare -fstack-protector -fno-stack-check -fvisibility=default -Wsuggest-override -Wno-unused-parameter>)
     target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:GNU>: -Wno-missing-field-initializers>)
 endfunction()
 
@@ -69,3 +69,4 @@ endif()
 # keep a separate main statement
 add_executable(ablate main.cpp)
 target_link_libraries(ablate PRIVATE ablateLibrary)
+ablate_default_target_compile_options_cxx(ablate)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,4 +69,3 @@ endif()
 # keep a separate main statement
 add_executable(ablate main.cpp)
 target_link_libraries(ablate PRIVATE ablateLibrary)
-ablate_default_target_compile_options_cxx(ablate)

--- a/ablateLibrary/CMakeLists.txt
+++ b/ablateLibrary/CMakeLists.txt
@@ -33,7 +33,7 @@ set(DISABLE_PETSCXDMFGENERATOR_TESTS ON CACHE BOOL "" FORCE)
 FetchContent_Declare(
         petscXdmfGenerator
         GIT_REPOSITORY https://github.com/UBCHREST/petscXdmfGenerator.git
-        GIT_TAG v0.0.8
+        GIT_TAG v0.0.9
 )
 FetchContent_MakeAvailable(petscXdmfGenerator)
 

--- a/ablateLibrary/environment/runEnvironment.cpp
+++ b/ablateLibrary/environment/runEnvironment.cpp
@@ -3,10 +3,7 @@
 #include <chrono>
 #include <iostream>
 
-std::unique_ptr<ablate::environment::RunEnvironment> ablate::environment::RunEnvironment::runEnvironment =
-    std::unique_ptr<ablate::environment::RunEnvironment>(new ablate::environment::RunEnvironment());
-
-ablate::environment::RunEnvironment::RunEnvironment() : outputDirectory(""), title("") {}
+ablate::environment::RunEnvironment::RunEnvironment() : outputDirectory(), title("") {}
 
 ablate::environment::RunEnvironment::RunEnvironment(const parameters::Parameters& parameters, std::filesystem::path inputPath) : title(parameters.GetExpect<std::string>("title")) {
     // check to see if the output directory is set

--- a/ablateLibrary/environment/runEnvironment.hpp
+++ b/ablateLibrary/environment/runEnvironment.hpp
@@ -1,6 +1,8 @@
 #ifndef ABLATELIBRARY_RUNENVIRONMENT_HPP
 #define ABLATELIBRARY_RUNENVIRONMENT_HPP
 #include <filesystem>
+#include <memory>
+#include <string>
 #include "parameters/parameters.hpp"
 
 namespace ablate::environment {
@@ -22,12 +24,17 @@ class RunEnvironment {
 
     // static access methods
     static void Setup(const parameters::Parameters&, std::filesystem::path inputPath = {});
-    inline static const RunEnvironment& Get() { return *runEnvironment; }
+    inline static const RunEnvironment& Get() {
+        if (!runEnvironment) {
+            runEnvironment.reset(new RunEnvironment());
+        }
+        return *runEnvironment;
+    }
 
     inline const std::filesystem::path& GetOutputDirectory() const { return outputDirectory; }
 
    private:
-    static std::unique_ptr<RunEnvironment> runEnvironment;
+    inline static std::unique_ptr<RunEnvironment> runEnvironment = std::unique_ptr<RunEnvironment>();
 };
 }  // namespace ablate::environment
 

--- a/ablateLibrary/mathFunctions/CMakeLists.txt
+++ b/ablateLibrary/mathFunctions/CMakeLists.txt
@@ -16,4 +16,6 @@ target_sources(ablateLibrary
         parsedSeries.cpp
         linearTable.hpp
         linearTable.cpp
+        parsedNested.hpp
+        parsedNested.cpp
         )

--- a/ablateLibrary/mathFunctions/parsedFunction.cpp
+++ b/ablateLibrary/mathFunctions/parsedFunction.cpp
@@ -18,7 +18,11 @@ ablate::mathFunctions::ParsedFunction::ParsedFunction(std::string functionString
     parser.SetExpr(formula);
 
     // Test the function
-    parser.Eval();
+    try {
+        parser.Eval();
+    } catch (mu::Parser::exception_type& exception) {
+        throw ablate::mathFunctions::ParsedFunction::ConvertToException(exception);
+    }
 }
 double ablate::mathFunctions::ParsedFunction::Eval(const double& x, const double& y, const double& z, const double& t) const {
     coordinate[0] = x;
@@ -39,6 +43,7 @@ double ablate::mathFunctions::ParsedFunction::Eval(const double* xyz, const int&
     time = t;
     return parser.Eval();
 }
+
 void ablate::mathFunctions::ParsedFunction::Eval(const double& x, const double& y, const double& z, const double& t, std::vector<double>& result) const {
     coordinate[0] = x;
     coordinate[1] = y;
@@ -119,6 +124,10 @@ PetscErrorCode ablate::mathFunctions::ParsedFunction::ParsedPetscFunction(PetscI
 void ablate::mathFunctions::ParsedFunction::DefineAdditionalFunctions(mu::Parser& parser) {
     // define some helper functions
     parser.DefineFun("Power", powerFunction, true);
+}
+
+std::invalid_argument ablate::mathFunctions::ParsedFunction::ConvertToException(mu::Parser::exception_type& exception) {
+    return std::invalid_argument("Unable to parser (" + exception.GetExpr() + "). " + exception.GetMsg());
 }
 
 #include "parser/registrar.hpp"

--- a/ablateLibrary/mathFunctions/parsedFunction.hpp
+++ b/ablateLibrary/mathFunctions/parsedFunction.hpp
@@ -38,6 +38,8 @@ class ParsedFunction : public MathFunction {
     PetscFunction GetPetscFunction() override { return ParsedPetscFunction; }
 
     static void DefineAdditionalFunctions(mu::Parser& parser);
+
+    static std::invalid_argument ConvertToException(mu::Parser::exception_type& exception);
 };
 }  // namespace ablate::mathFunctions
 

--- a/ablateLibrary/mathFunctions/parsedNested.cpp
+++ b/ablateLibrary/mathFunctions/parsedNested.cpp
@@ -13,14 +13,11 @@ ablate::mathFunctions::ParsedNested::ParsedNested(std::string functionString, st
         // store the function
         nestedFunctions.push_back(nestedFunction.second);
 
-        // Create a new pointer to a double value
-        double* value = new double;
-
         // store the pointer
-        nestedValues.push_back(value);
+        nestedValues.push_back(std::make_unique<double>(0.0));
 
         // register this with the parser
-        parser.DefineVar(nestedFunction.first, value);
+        parser.DefineVar(nestedFunction.first, nestedValues.back().get());
     }
 
     // define any additional helper functions
@@ -32,13 +29,6 @@ ablate::mathFunctions::ParsedNested::ParsedNested(std::string functionString, st
         parser.Eval();
     } catch (mu::Parser::exception_type& exception) {
         throw ablate::mathFunctions::ParsedFunction::ConvertToException(exception);
-    }
-}
-
-ablate::mathFunctions::ParsedNested::~ParsedNested() {
-    for (auto& pointer : nestedValues) {
-        delete pointer;
-        pointer = nullptr;
     }
 }
 
@@ -144,7 +134,7 @@ PetscErrorCode ablate::mathFunctions::ParsedNested::ParsedPetscNested(PetscInt d
 
         // updated the nested functions
         for (std::size_t i = 0; i < parser->nestedValues.size(); i++) {
-            parser->nestedFunctions[i]->GetPetscFunction()(dim, time, x, 1, parser->nestedValues[i], parser->nestedFunctions[i]->GetContext());
+            parser->nestedFunctions[i]->GetPetscFunction()(dim, time, x, 1, parser->nestedValues[i].get(), parser->nestedFunctions[i]->GetContext());
         }
 
         // Evaluate

--- a/ablateLibrary/mathFunctions/parsedNested.cpp
+++ b/ablateLibrary/mathFunctions/parsedNested.cpp
@@ -1,0 +1,173 @@
+#include "parsedNested.hpp"
+#include "parsedFunction.hpp"
+
+ablate::mathFunctions::ParsedNested::ParsedNested(std::string functionString, std::map<std::string, std::shared_ptr<MathFunction>> nestedFunctionsIn) : formula(functionString) {
+    // define the x,y,z and t variables
+    parser.DefineVar("x", &coordinate[0]);
+    parser.DefineVar("y", &coordinate[1]);
+    parser.DefineVar("z", &coordinate[2]);
+    parser.DefineVar("t", &time);
+
+    // for every nestedFunction passed in , use it
+    for (auto nestedFunction : nestedFunctionsIn) {
+        // store the function
+        nestedFunctions.push_back(nestedFunction.second);
+
+        // Create a new pointer to a double value
+        double* value = new double;
+
+        // store the pointer
+        nestedValues.push_back(value);
+
+        // register this with the parser
+        parser.DefineVar(nestedFunction.first, value);
+    }
+
+    // define any additional helper functions
+    ablate::mathFunctions::ParsedFunction::DefineAdditionalFunctions(parser);
+    parser.SetExpr(formula);
+
+    // Test the function
+    try {
+        parser.Eval();
+    } catch (mu::Parser::exception_type& exception) {
+        throw ablate::mathFunctions::ParsedFunction::ConvertToException(exception);
+    }
+}
+
+ablate::mathFunctions::ParsedNested::~ParsedNested() {
+    for (auto& pointer : nestedValues) {
+        delete pointer;
+        pointer = nullptr;
+    }
+}
+
+double ablate::mathFunctions::ParsedNested::Eval(const double& x, const double& y, const double& z, const double& t) const {
+    coordinate[0] = x;
+    coordinate[1] = y;
+    coordinate[2] = z;
+    time = t;
+
+    // updated the nested functions
+    for (std::size_t i = 0; i < nestedValues.size(); i++) {
+        *nestedValues[i] = nestedFunctions[i]->Eval(x, y, z, t);
+    }
+
+    return parser.Eval();
+}
+
+double ablate::mathFunctions::ParsedNested::Eval(const double* xyz, const int& ndims, const double& t) const {
+    coordinate[0] = 0;
+    coordinate[1] = 0;
+    coordinate[2] = 0;
+
+    for (auto d = 0; d < std::min(ndims, 3); d++) {
+        coordinate[d] = xyz[d];
+    }
+    time = t;
+
+    // updated the nested functions
+    for (std::size_t i = 0; i < nestedValues.size(); i++) {
+        *nestedValues[i] = nestedFunctions[i]->Eval(xyz, ndims, t);
+    }
+
+    return parser.Eval();
+}
+
+void ablate::mathFunctions::ParsedNested::Eval(const double& x, const double& y, const double& z, const double& t, std::vector<double>& result) const {
+    coordinate[0] = x;
+    coordinate[1] = y;
+    coordinate[2] = z;
+    time = t;
+
+    // updated the nested functions
+    for (std::size_t i = 0; i < nestedValues.size(); i++) {
+        *nestedValues[i] = nestedFunctions[i]->Eval(x, y, z, t);
+    }
+
+    int functionSize = 0;
+    auto rawResult = parser.Eval(functionSize);
+
+    if ((int)result.size() < functionSize) {
+        throw std::invalid_argument("The result vector is not sized to hold the function " + parser.GetExpr());
+    }
+
+    // copy over
+    for (auto i = 0; i < functionSize; i++) {
+        result[i] = rawResult[i];
+    }
+}
+
+void ablate::mathFunctions::ParsedNested::Eval(const double* xyz, const int& ndims, const double& t, std::vector<double>& result) const {
+    coordinate[0] = 0;
+    coordinate[1] = 0;
+    coordinate[2] = 0;
+
+    // updated the nested functions
+    for (std::size_t i = 0; i < nestedValues.size(); i++) {
+        *nestedValues[i] = nestedFunctions[i]->Eval(xyz, ndims, t);
+    }
+
+    for (auto i = 0; i < std::min(ndims, 3); i++) {
+        coordinate[i] = xyz[i];
+    }
+    time = t;
+
+    int functionSize = 0;
+    auto rawResult = parser.Eval(functionSize);
+
+    if ((int)result.size() < functionSize) {
+        throw std::invalid_argument("The result vector is not sized to hold the function " + parser.GetExpr());
+    }
+
+    // copy over
+    for (auto i = 0; i < functionSize; i++) {
+        result[i] = rawResult[i];
+    }
+}
+
+PetscErrorCode ablate::mathFunctions::ParsedNested::ParsedPetscNested(PetscInt dim, PetscReal time, const PetscReal* x, PetscInt nf, PetscScalar* u, void* ctx) {
+    // wrap in try, so we return petsc error code instead of c++ exception
+    PetscFunctionBeginUser;
+    try {
+        auto parser = (ParsedNested*)ctx;
+
+        // update the coordinates
+        parser->coordinate[0] = 0;
+        parser->coordinate[1] = 0;
+        parser->coordinate[2] = 0;
+
+        for (auto i = 0; i < std::min(dim, 3); i++) {
+            parser->coordinate[i] = x[i];
+        }
+        parser->time = time;
+
+        // updated the nested functions
+        for (std::size_t i = 0; i < parser->nestedValues.size(); i++) {
+            parser->nestedFunctions[i]->GetPetscFunction()(dim, time, x, 1, parser->nestedValues[i], parser->nestedFunctions[i]->GetContext());
+        }
+
+        // Evaluate
+        int functionSize = 0;
+        auto rawResult = parser->parser.Eval(functionSize);
+
+        if (nf < functionSize) {
+            throw std::invalid_argument("The result vector is not sized to hold the function " + parser->parser.GetExpr());
+        }
+
+        // copy over
+        for (auto i = 0; i < functionSize; i++) {
+            u[i] = rawResult[i];
+        }
+
+    } catch (std::exception& exception) {
+        SETERRQ(PETSC_COMM_SELF, PETSC_ERR_LIB, exception.what());
+    }
+    PetscFunctionReturn(0);
+}
+
+#include "parser/registrar.hpp"
+REGISTER(ablate::mathFunctions::MathFunction, ablate::mathFunctions::ParsedNested,
+         " computes string function with variables x, y, z, and t where additional variables can be specified using other functions",
+         ARG(std::string, "formula", "see ParsedFunction for details on the string formatting."),
+         ARG(std::map<std::string TMP_COMMA ablate::mathFunctions::MathFunction>, "nested", "a map of nested MathFunctions.  These functions are assumed to compute a single scalar value"));

--- a/ablateLibrary/mathFunctions/parsedNested.hpp
+++ b/ablateLibrary/mathFunctions/parsedNested.hpp
@@ -1,0 +1,45 @@
+#ifndef ABLATELIBRARY_PARSEDNESTED_HPP
+#define ABLATELIBRARY_PARSEDNESTED_HPP
+
+#include <muParser.h>
+#include <memory>
+#include <vector>
+#include "mathFunction.hpp"
+
+namespace ablate::mathFunctions {
+class ParsedNested : public MathFunction {
+   private:
+    mutable double coordinate[3] = {0, 0, 0};
+    mutable double time = 0.0;
+
+    mu::Parser parser;
+    const std::string formula;
+
+    // store the scratch variables
+    std::vector<double*> nestedValues;
+    std::vector<std::shared_ptr<MathFunction>> nestedFunctions;
+
+   private:
+    static PetscErrorCode ParsedPetscNested(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nf, PetscScalar* u, void* ctx);
+
+   public:
+    ParsedNested(const ParsedNested&) = delete;
+    void operator=(const ParsedNested&) = delete;
+
+    explicit ParsedNested(std::string functionString, std::map<std::string, std::shared_ptr<MathFunction>>);
+    ~ParsedNested() override;
+
+    double Eval(const double& x, const double& y, const double& z, const double& t) const override;
+
+    double Eval(const double* xyz, const int& ndims, const double& t) const override;
+
+    void Eval(const double& x, const double& y, const double& z, const double& t, std::vector<double>& result) const override;
+
+    void Eval(const double* xyz, const int& ndims, const double& t, std::vector<double>& result) const override;
+
+    void* GetContext() override { return this; }
+
+    PetscFunction GetPetscFunction() override { return ParsedPetscNested; }
+};
+}  // namespace ablate::mathFunctions
+#endif  // ABLATELIBRARY_PARSEDNESTED_HPP

--- a/ablateLibrary/mathFunctions/parsedNested.hpp
+++ b/ablateLibrary/mathFunctions/parsedNested.hpp
@@ -16,7 +16,7 @@ class ParsedNested : public MathFunction {
     const std::string formula;
 
     // store the scratch variables
-    std::vector<double*> nestedValues;
+    std::vector<std::unique_ptr<double>> nestedValues;
     std::vector<std::shared_ptr<MathFunction>> nestedFunctions;
 
    private:
@@ -27,7 +27,6 @@ class ParsedNested : public MathFunction {
     void operator=(const ParsedNested&) = delete;
 
     explicit ParsedNested(std::string functionString, std::map<std::string, std::shared_ptr<MathFunction>>);
-    ~ParsedNested() override;
 
     double Eval(const double& x, const double& y, const double& z, const double& t) const override;
 

--- a/ablateLibrary/mathFunctions/parsedSeries.cpp
+++ b/ablateLibrary/mathFunctions/parsedSeries.cpp
@@ -18,8 +18,13 @@ ablate::mathFunctions::ParsedSeries::ParsedSeries(std::string functionString, in
     parser.SetExpr(formula);
 
     // Test the function
-    parser.Eval();
+    try {
+        parser.Eval();
+    } catch (mu::Parser::exception_type& exception) {
+        throw ablate::mathFunctions::ParsedFunction::ConvertToException(exception);
+    }
 }
+
 double ablate::mathFunctions::ParsedSeries::Eval(const double& x, const double& y, const double& z, const double& t) const {
     coordinate[0] = x;
     coordinate[1] = y;

--- a/ablateLibrary/parser/factory.hpp
+++ b/ablateLibrary/parser/factory.hpp
@@ -90,6 +90,26 @@ class Factory {
     }
 
     template <typename Interface>
+    std::map<std::string, std::shared_ptr<Interface>> Get(const ArgumentIdentifier<std::map<std::string, Interface>>& identifier) const {
+        if (identifier.optional && !Contains(identifier.inputName)) {
+            return {};
+        }
+
+        auto childFactory = GetFactory(identifier.inputName);
+        auto childrenNames = childFactory->GetKeys();
+
+        // Build and resolve the list
+        std::map<std::string, std::shared_ptr<Interface>> results;
+        for (auto childName : childrenNames) {
+            auto subChildFactory = childFactory->GetFactory(childName);
+
+            results[childName] = (ResolveAndCreate<Interface>(subChildFactory));
+        }
+
+        return results;
+    }
+
+    template <typename Interface>
     inline auto GetByName(const std::string inputName) {
         return Get(ArgumentIdentifier<Interface>{.inputName = inputName});
     }

--- a/ablateLibrary/utilities/fileUtility.cpp
+++ b/ablateLibrary/utilities/fileUtility.cpp
@@ -6,7 +6,7 @@
 std::filesystem::path ablate::utilities::FileUtility::LocateFile(std::string file, MPI_Comm com, std::vector<std::filesystem::path> searchPaths, std::filesystem::path remoteRelocatePath) {
     // check to see if the path exists
     if (std::filesystem::exists(file)) {
-        return file;
+        return std::filesystem::path(file);
     }
 
     // check to see if the file specified is really a url

--- a/tests/ablateLibrary/mathFunctions/CMakeLists.txt
+++ b/tests/ablateLibrary/mathFunctions/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(libraryTests
         constantValueTests.cpp
         parsedSeriesTests.cpp
         linearInterpolatorTests.cpp
+        parsedNestedTests.cpp
         )

--- a/tests/ablateLibrary/mathFunctions/parsedFunctionTests.cpp
+++ b/tests/ablateLibrary/mathFunctions/parsedFunctionTests.cpp
@@ -23,7 +23,7 @@ TEST(ParsedFunctionTests, ShouldBeCreatedFromRegistar) {
 
 TEST(ParsedFunctionTests, ShouldThrowExceptionInvalidEquation) {
     // arrange/act/assert
-    ASSERT_ANY_THROW(ablate::mathFunctions::ParsedFunction("x+y+z+t+c"));
+    ASSERT_THROW(ablate::mathFunctions::ParsedFunction("x+y+z+t+c"), std::invalid_argument);
 }
 
 TEST(ParsedFunctionTests, ShouldEvalToScalarFromXYZ) {

--- a/tests/ablateLibrary/mathFunctions/parsedNestedTests.cpp
+++ b/tests/ablateLibrary/mathFunctions/parsedNestedTests.cpp
@@ -1,0 +1,141 @@
+#include <map>
+#include <memory>
+#include "gtest/gtest.h"
+#include "mathFunctions/functionFactory.hpp"
+#include "mathFunctions/parsedNested.hpp"
+#include "parser/mockFactory.hpp"
+#include "parser/registrar.hpp"
+
+namespace ablateTesting::mathFunctions {
+
+TEST(ParsedNestedTests, ShouldBeCreatedFromRegistar) {
+    // arrange
+    std::shared_ptr<ablateTesting::parser::MockFactory> mockFactory = std::make_shared<ablateTesting::parser::MockFactory>();
+    const std::string expectedClassType = "ablate::mathFunctions::ParsedSeries";
+    EXPECT_CALL(*mockFactory, GetClassType()).Times(::testing::Exactly(1)).WillOnce(::testing::ReturnRef(expectedClassType));
+    EXPECT_CALL(*mockFactory, Get(ablate::parser::ArgumentIdentifier<std::string>{.inputName = "formula"})).Times(::testing::Exactly(1)).WillOnce(::testing::Return("x+y+z+t"));
+
+    std::shared_ptr<ablateTesting::parser::MockFactory> childFactory = std::make_shared<ablateTesting::parser::MockFactory>();
+    EXPECT_CALL(*mockFactory, GetFactory("nested")).Times(::testing::Exactly(1)).WillOnce(::testing::Return(childFactory));
+    EXPECT_CALL(*childFactory, GetKeys()).Times(::testing::Exactly(1));
+
+    // act
+    auto instance = ResolveAndCreate<ablate::mathFunctions::MathFunction>(mockFactory);
+
+    // assert
+    ASSERT_TRUE(instance != nullptr) << " should create an instance of the ParsedNested";
+    ASSERT_TRUE(std::dynamic_pointer_cast<ablate::mathFunctions::ParsedNested>(instance) != nullptr) << " should be an instance of ParsedNested";
+}
+
+TEST(ParsedNestedTests, ShouldThrowExceptionInvalidEquation) {
+    // arrange/act/assert
+    ASSERT_ANY_THROW(ablate::mathFunctions::ParsedNested("x+y+z+t+c", {}));
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+struct ParsedNestedTestsScalarParameters {
+    std::string formula;
+    std::map<std::string, std::shared_ptr<ablate::mathFunctions::MathFunction>> nested;
+    double expectedResult;
+};
+
+class ParsedNestedTestsScalarFixture : public ::testing::TestWithParam<ParsedNestedTestsScalarParameters> {};
+
+TEST_P(ParsedNestedTestsScalarFixture, ShouldComputeCorrectAnswerFromXYZ) {
+    // arrange
+    const auto& param = GetParam();
+    auto function = ablate::mathFunctions::ParsedNested(param.formula, param.nested);
+
+    // act/assert
+    ASSERT_DOUBLE_EQ(param.expectedResult, function.Eval(1.0, 2.0, 3.0, 4.0));
+}
+
+TEST_P(ParsedNestedTestsScalarFixture, ShouldComputeCorrectAnswerFromCoord) {
+    // arrange
+    const auto& param = GetParam();
+    auto function = ablate::mathFunctions::ParsedNested(param.formula, param.nested);
+
+    const double array1[3] = {1.0, 2.0, 3.0};
+
+    // act/assert
+    ASSERT_DOUBLE_EQ(param.expectedResult, function.Eval(array1, 3, 4.0));
+}
+
+INSTANTIATE_TEST_SUITE_P(ParsedNestedTests, ParsedNestedTestsScalarFixture,
+                         testing::Values((ParsedNestedTestsScalarParameters){.formula = "v*x", .nested = {{"v", ablate::mathFunctions::Create(2.0)}}, .expectedResult = 2.0},
+                                         (ParsedNestedTestsScalarParameters){.formula = "v*x + z", .nested = {{"v", ablate::mathFunctions::Create("3.0*y")}}, .expectedResult = 9.0},
+                                         (ParsedNestedTestsScalarParameters){.formula = "t*vel + test",
+                                                                             .nested = {{"vel", ablate::mathFunctions::Create("3.0*y")}, {"test", ablate::mathFunctions::Create("z")}},
+                                                                             .expectedResult = 27}));
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+struct ParsedNestedTestsVectorParameters {
+    std::string formula;
+    std::map<std::string, std::shared_ptr<ablate::mathFunctions::MathFunction>> nested;
+    std::vector<double> expectedResult;
+};
+
+class ParsedNestedTestsVectorFixture : public ::testing::TestWithParam<ParsedNestedTestsVectorParameters> {};
+
+TEST_P(ParsedNestedTestsVectorFixture, ShouldComputeCorrectAnswerFromXYZ) {
+    // arrange
+    const auto& param = GetParam();
+    auto function = ablate::mathFunctions::ParsedNested(param.formula, param.nested);
+    std::vector<double> result(param.expectedResult.size(), NAN);
+
+    // act
+    function.Eval(1.0, 2.0, 3.0, 4.0, result);
+
+    // assert
+    for (std::size_t i = 0; i < param.expectedResult.size(); i++) {
+        ASSERT_DOUBLE_EQ(param.expectedResult[i], result[i]);
+    }
+}
+
+TEST_P(ParsedNestedTestsVectorFixture, ShouldComputeCorrectAnswerFromCoord) {
+    // arrange
+    const auto& param = GetParam();
+    auto function = ablate::mathFunctions::ParsedNested(param.formula, param.nested);
+    std::vector<double> result(param.expectedResult.size(), NAN);
+
+    const double array[3] = {1.0, 2.0, 3.0};
+
+    // act
+    function.Eval(array, 3, 4, result);
+
+    // assert
+    for (std::size_t i = 0; i < param.expectedResult.size(); i++) {
+        ASSERT_DOUBLE_EQ(param.expectedResult[i], result[i]);
+    }
+}
+
+TEST_P(ParsedNestedTestsVectorFixture, ShouldComputeCorrectAnswerPetscFunction) {
+    // arrange
+    const auto& param = GetParam();
+    auto function = ablate::mathFunctions::ParsedNested(param.formula, param.nested);
+    std::vector<double> result(param.expectedResult.size(), NAN);
+
+    const double array[3] = {1.0, 2.0, 3.0};
+
+    auto context = function.GetContext();
+    auto functionPointer = function.GetPetscFunction();
+
+    // act
+    auto errorCode = functionPointer(3, 4.0, array, result.size(), &result[0], context);
+
+    // assert
+    ASSERT_EQ(errorCode, 0);
+    for (std::size_t i = 0; i < param.expectedResult.size(); i++) {
+        ASSERT_DOUBLE_EQ(param.expectedResult[i], result[i]);
+    }
+}
+INSTANTIATE_TEST_SUITE_P(ParsedNestedTests, ParsedNestedTestsVectorFixture,
+                         testing::Values((ParsedNestedTestsVectorParameters){.formula = "v*x", .nested = {{"v", ablate::mathFunctions::Create(2.0)}}, .expectedResult = {2.0}},
+                                         (ParsedNestedTestsVectorParameters){.formula = "v*x + z", .nested = {{"v", ablate::mathFunctions::Create("3.0*y")}}, .expectedResult = {9.0}},
+                                         (ParsedNestedTestsVectorParameters){.formula = "t*vel + test",
+                                                                             .nested = {{"vel", ablate::mathFunctions::Create("3.0*y")}, {"test", ablate::mathFunctions::Create("z")}},
+                                                                             .expectedResult = {27}},
+                                         (ParsedNestedTestsVectorParameters){.formula = "v*x, v*z + y", .nested = {{"v", ablate::mathFunctions::Create("3.0*y")}}, .expectedResult = {6, 20}},
+                                         (ParsedNestedTestsVectorParameters){.formula = "0, i*y, t/i", .nested = {{"i", ablate::mathFunctions::Create(10.0)}}, .expectedResult = {0, 20, 0.4}}));
+
+}  // namespace ablateTesting::mathFunctions

--- a/tests/ablateLibrary/mathFunctions/parsedSeriesTests.cpp
+++ b/tests/ablateLibrary/mathFunctions/parsedSeriesTests.cpp
@@ -25,7 +25,7 @@ TEST(ParsedSeriesTests, ShouldBeCreatedFromRegistar) {
 
 TEST(ParsedSeriesTests, ShouldThrowExceptionInvalidEquation) {
     // arrange/act/assert
-    ASSERT_ANY_THROW(ablate::mathFunctions::ParsedSeries("x+y+z+t+c"));
+    ASSERT_THROW(ablate::mathFunctions::ParsedSeries("x+y+z+t+c"), std::invalid_argument);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/ablateLibrary/parser/factoryTests.cpp
+++ b/tests/ablateLibrary/parser/factoryTests.cpp
@@ -196,5 +196,4 @@ TEST(FactoryTests, ShouldGetMapOfSharedPointers) {
     ASSERT_TRUE(std::dynamic_pointer_cast<FactoryMockClass1>(result["key1"]) != nullptr);
     ASSERT_TRUE(std::dynamic_pointer_cast<FactoryMockClass1>(result["key2"]) != nullptr);
 }
-
 }  // namespace ablateTesting::parser

--- a/tests/ablateLibrary/parser/factoryTests.cpp
+++ b/tests/ablateLibrary/parser/factoryTests.cpp
@@ -42,6 +42,21 @@ TEST(FactoryTests, ShouldReturnEmptyListWhenOptional) {
     ASSERT_TRUE(result.empty());
 }
 
+TEST(FactoryTests, ShouldReturnEmptyMapWhenOptional) {
+    // arrange
+
+    ablate::parser::Registrar<FactoryMockClass1>::Register<FactoryMockClass1>(true, "FactoryMockClass1", "this is a simple mock class");
+    auto mockFactory = std::make_shared<MockFactory>();
+    EXPECT_CALL(*mockFactory, Contains(std::string("input123"))).Times(::testing::Exactly(1)).WillOnce(::testing::Return(false));
+
+    // act
+    auto argument = ArgumentIdentifier<std::map<std::string, FactoryMockClass1>>{.inputName = "input123", .optional = true};
+    auto result = std::dynamic_pointer_cast<Factory>(mockFactory)->Get(argument);
+
+    // assert
+    ASSERT_TRUE(result.empty());
+}
+
 TEST(FactoryTests, GetByNameShouldCallGetWithCorrectArguments) {
     // arrange
     MockFactory mockFactory;
@@ -151,6 +166,35 @@ TEST(FactoryTests, ShouldReturnEnumFromString) {
 
     // assert
     ASSERT_EQ(result, TestEnum::COMPONENT);
+}
+
+TEST(FactoryTests, ShouldGetMapOfSharedPointers) {
+    // arrange
+    const std::string defaultClassType = "FactoryMockClass1";
+    ablate::parser::Registrar<FactoryMockClass1>::Register<FactoryMockClass1>(true, std::string(defaultClassType), "this is a simple mock class");
+    auto mockFactory = std::make_shared<MockFactory>();
+
+    // subChildFactory
+    auto subChildFactory = std::make_shared<MockFactory>();
+    EXPECT_CALL(*mockFactory, GetFactory("input123")).Times(::testing::Exactly(1)).WillOnce(::testing::Return(subChildFactory));
+    EXPECT_CALL(*subChildFactory, GetKeys()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::unordered_set<std::string>{"key1", "key2"}));
+
+    auto factoryChild1 = std::make_shared<MockFactory>();
+    EXPECT_CALL(*subChildFactory, GetFactory("key1")).Times(::testing::Exactly(1)).WillOnce(::testing::Return(factoryChild1));
+    EXPECT_CALL(*factoryChild1, GetClassType()).Times(::testing::Exactly(1)).WillOnce(::testing::ReturnRef(defaultClassType));
+
+    auto factoryChild2 = std::make_shared<MockFactory>();
+    EXPECT_CALL(*subChildFactory, GetFactory("key2")).Times(::testing::Exactly(1)).WillOnce(::testing::Return(factoryChild2));
+    EXPECT_CALL(*factoryChild2, GetClassType()).Times(::testing::Exactly(1)).WillOnce(::testing::ReturnRef(defaultClassType));
+
+    // act
+    auto argument = ArgumentIdentifier<std::map<std::string, FactoryMockClass1>>{.inputName = "input123", .optional = false};
+    auto result = std::dynamic_pointer_cast<Factory>(mockFactory)->Get(argument);
+
+    // assert
+    ASSERT_EQ(result.size(), 2);
+    ASSERT_TRUE(std::dynamic_pointer_cast<FactoryMockClass1>(result["key1"]) != nullptr);
+    ASSERT_TRUE(std::dynamic_pointer_cast<FactoryMockClass1>(result["key2"]) != nullptr);
 }
 
 }  // namespace ablateTesting::parser


### PR DESCRIPTION
this adds support for nested or sub functions used in parsed functions.  This allows for a series to be computed and used in another equation and closes #116 .  This PR also makes figuring out mu parser errors easier. 