### PR TITLE
added ablate::finiteVolume::processes::ArbitrarySource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # Set the project details
-project(ablateLibrary VERSION 0.7.34)
+project(ablateLibrary VERSION 0.7.35)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/ablateLibrary/finiteVolume/finiteVolumeSolver.cpp
+++ b/ablateLibrary/finiteVolume/finiteVolumeSolver.cpp
@@ -275,7 +275,7 @@ void ablate::finiteVolume::FiniteVolumeSolver::ComputeSourceTerms(PetscReal time
     }
     if (!this->rhsPointFunctionDescriptions.empty()) {
         ComputePointSourceTerms(
-            dm, ds, totDim, xArray, dmAux, dsAux, totDimAux, auxArray, faceDM, faceGeomArray, cellDM, cellGeomArray, dmGrads, locGradArrays, dmAuxGrads, locAuxGradArrays, locFArray);
+            dm, ds, totDim, time, xArray, dmAux, dsAux, totDimAux, auxArray, faceDM, faceGeomArray, cellDM, cellGeomArray, dmGrads, locGradArrays, dmAuxGrads, locAuxGradArrays, locFArray);
     }
 
     // cleanup (restore access to locGradVecs, locAuxGradVecs with DMRestoreLocalVector)
@@ -753,7 +753,7 @@ void ablate::finiteVolume::FiniteVolumeSolver::ComputeFluxSourceTerms(DM dm, Pet
 
     RestoreRange(faceIS, fStart, fEnd, faces);
 }
-void ablate::finiteVolume::FiniteVolumeSolver::ComputePointSourceTerms(DM dm, PetscDS ds, PetscInt totDim, const PetscScalar* xArray, DM dmAux, PetscDS dsAux, PetscInt totDimAux,
+void ablate::finiteVolume::FiniteVolumeSolver::ComputePointSourceTerms(DM dm, PetscDS ds, PetscInt totDim, PetscReal time, const PetscScalar* xArray, DM dmAux, PetscDS dsAux, PetscInt totDimAux,
                                                                        const PetscScalar* auxArray, DM faceDM, const PetscScalar* faceGeomArray, DM cellDM, const PetscScalar* cellGeomArray,
                                                                        std::vector<DM>& dmGrads, std::vector<const PetscScalar*>& locGradArrays, std::vector<DM>& dmAuxGrads,
                                                                        std::vector<const PetscScalar*>& locAuxGradArrays, PetscScalar* locFArray) {
@@ -842,7 +842,7 @@ void ablate::finiteVolume::FiniteVolumeSolver::ComputePointSourceTerms(DM dm, Pe
         // March over each functionDescriptions
         for (std::size_t fun = 0; fun < rhsPointFunctionDescriptions.size(); fun++) {
             // (PetscInt dim, const PetscFVCellGeom *cg, const PetscInt uOff[], const PetscScalar u[], const PetscInt aOff[], const PetscScalar a[], PetscScalar f[], void *ctx)
-            rhsPointFunctionDescriptions[fun].function(dim, cg, &uOff[fun][0], u, gradU, &aOff[fun][0], a, gradAux, fScratch, rhsPointFunctionDescriptions[fun].context) >> checkError;
+            rhsPointFunctionDescriptions[fun].function(dim, time, cg, &uOff[fun][0], u, gradU, &aOff[fun][0], a, gradAux, fScratch, rhsPointFunctionDescriptions[fun].context) >> checkError;
 
             // copy over each result flux field
             PetscInt r = 0;

--- a/ablateLibrary/finiteVolume/finiteVolumeSolver.hpp
+++ b/ablateLibrary/finiteVolume/finiteVolumeSolver.hpp
@@ -25,8 +25,8 @@ class FiniteVolumeSolver : public solver::CellSolver, public solver::RHSFunction
     using FVMRHSFluxFunction = PetscErrorCode (*)(PetscInt dim, const PetscFVFaceGeom* fg, const PetscInt uOff[], const PetscInt uOff_x[], const PetscScalar fieldL[], const PetscScalar fieldR[],
                                                   const PetscScalar gradL[], const PetscScalar gradR[], const PetscInt aOff[], const PetscInt aOff_x[], const PetscScalar auxL[],
                                                   const PetscScalar auxR[], const PetscScalar gradAuxL[], const PetscScalar gradAuxR[], PetscScalar flux[], void* ctx);
-    using FVMRHSPointFunction = PetscErrorCode (*)(PetscInt dim, const PetscFVCellGeom* cg, const PetscInt uOff[], const PetscScalar u[], const PetscScalar* const gradU[], const PetscInt aOff[],
-                                                   const PetscScalar a[], const PetscScalar* const gradA[], PetscScalar f[], void* ctx);
+    using FVMRHSPointFunction = PetscErrorCode (*)(PetscInt dim, PetscReal time, const PetscFVCellGeom* cg, const PetscInt uOff[], const PetscScalar u[], const PetscScalar* const gradU[],
+                                                   const PetscInt aOff[], const PetscScalar a[], const PetscScalar* const gradA[], PetscScalar f[], void* ctx);
 
    private:
     /**
@@ -109,7 +109,7 @@ class FiniteVolumeSolver : public solver::CellSolver, public solver::RHSFunction
     /**
      * Function to compute the point source terms
      */
-    void ComputePointSourceTerms(DM dm, PetscDS ds, PetscInt totDim, const PetscScalar* xArray, DM dmAux, PetscDS dsAux, PetscInt totDimAux, const PetscScalar* auxArray, DM faceDM,
+    void ComputePointSourceTerms(DM dm, PetscDS ds, PetscInt totDim, PetscReal time, const PetscScalar* xArray, DM dmAux, PetscDS dsAux, PetscInt totDimAux, const PetscScalar* auxArray, DM faceDM,
                                  const PetscScalar* faceGeomArray, DM cellDM, const PetscScalar* cellGeomArray, std::vector<DM>& dmGrads, std::vector<const PetscScalar*>& locGradArrays,
                                  std::vector<DM>& dmAuxGrads, std::vector<const PetscScalar*>& locAuxGradArrays, PetscScalar* locFArray);
 

--- a/ablateLibrary/finiteVolume/processes/CMakeLists.txt
+++ b/ablateLibrary/finiteVolume/processes/CMakeLists.txt
@@ -17,4 +17,6 @@ target_sources(ablateLibrary
         gravity.cpp
         pressureGradientScaling.hpp
         pressureGradientScaling.cpp
+        arbitrarySource.hpp
+        arbitrarySource.cpp
         )

--- a/ablateLibrary/finiteVolume/processes/arbitrarySource.cpp
+++ b/ablateLibrary/finiteVolume/processes/arbitrarySource.cpp
@@ -1,0 +1,30 @@
+
+#include "arbitrarySource.hpp"
+ablate::finiteVolume::processes::ArbitrarySource::ArbitrarySource(std::map<std::string, std::shared_ptr<ablate::mathFunctions::MathFunction>> functions) : functions(std::move(functions)) {}
+
+void ablate::finiteVolume::processes::ArbitrarySource::Initialize(ablate::finiteVolume::FiniteVolumeSolver &fvmSolver) {
+    for (const auto &[fieldName, function] : functions) {
+        // Get the field from the subDomain
+        const auto &field = fvmSolver.GetSubDomain().GetField(fieldName);
+
+        petscFunctions.emplace_back(PetscFunctionStruct{.petscFunction = function->GetPetscFunction(), .petscContext = function->GetContext(), .fieldSize = field.numberComponents});
+
+        // add the source function
+        fvmSolver.RegisterRHSFunction(ComputeArbitrarySource, &petscFunctions.back(), {fieldName}, {}, {});
+    }
+}
+
+PetscErrorCode ablate::finiteVolume::processes::ArbitrarySource::ComputeArbitrarySource(PetscInt dim, PetscReal time, const PetscFVCellGeom *cg, const PetscInt *uOff, const PetscScalar *u,
+                                                                                        const PetscScalar *const *gradU, const PetscInt *aOff, const PetscScalar *a, const PetscScalar *const *gradA,
+                                                                                        PetscScalar *f, void *ctx) {
+    PetscFunctionBegin;
+    auto function = (PetscFunctionStruct *)ctx;
+    PetscErrorCode ierr = function->petscFunction(dim, time, cg->centroid, function->fieldSize, f, function->petscContext);
+    CHKERRQ(ierr);
+    PetscFunctionReturn(0);
+}
+
+#include "registrar.hpp"
+#define COMMA ,
+REGISTER_PASS_THROUGH(ablate::finiteVolume::processes::Process, ablate::finiteVolume::processes::ArbitrarySource, "uses math functions to add arbitrary sources to the fvm method",
+                      std::map<std::string COMMA ablate::mathFunctions::MathFunction>);

--- a/ablateLibrary/finiteVolume/processes/arbitrarySource.hpp
+++ b/ablateLibrary/finiteVolume/processes/arbitrarySource.hpp
@@ -1,0 +1,42 @@
+#ifndef ABLATELIBRARY_ARBITRARYSOURCE_HPP
+#define ABLATELIBRARY_ARBITRARYSOURCE_HPP
+
+#include "process.hpp"
+namespace ablate::finiteVolume::processes {
+/**
+ * This class uses math functions to add arbitrary sources to the fvm method
+ */
+class ArbitrarySource : public Process {
+    //! list of functions used to compute the arbitrary source
+    const std::map<std::string, std::shared_ptr<ablate::mathFunctions::MathFunction>> functions;
+
+    /**
+     * private function to compute  source
+     * @return
+     */
+    static PetscErrorCode ComputeArbitrarySource(PetscInt dim, PetscReal time, const PetscFVCellGeom* cg, const PetscInt uOff[], const PetscScalar u[], const PetscScalar* const gradU[],
+                                                 const PetscInt aOff[], const PetscScalar a[], const PetscScalar* const gradA[], PetscScalar f[], void* ctx);
+
+    //! pre store the petsc function and context
+    struct PetscFunctionStruct {
+        mathFunctions::PetscFunction petscFunction;
+        void* petscContext;
+        PetscInt fieldSize;
+    };
+
+    //! Store pointers to the petsc functions
+    std::vector<PetscFunctionStruct> petscFunctions;
+
+   public:
+    explicit ArbitrarySource(std::map<std::string, std::shared_ptr<ablate::mathFunctions::MathFunction>> functions);
+
+    /**
+     * public function to link this process with the fvm solver
+     * @param flow
+     */
+    void Initialize(ablate::finiteVolume::FiniteVolumeSolver& fvmSolver) override;
+};
+
+}  // namespace ablate::finiteVolume::processes
+
+#endif  // ABLATELIBRARY_ARBITRARYSOURCE_HPP

--- a/ablateLibrary/finiteVolume/processes/gravity.cpp
+++ b/ablateLibrary/finiteVolume/processes/gravity.cpp
@@ -66,8 +66,9 @@ PetscErrorCode ablate::finiteVolume::processes::Gravity::UpdateAverageDensity(TS
     PetscFunctionReturn(0);
 }
 
-PetscErrorCode ablate::finiteVolume::processes::Gravity::ComputeGravitySource(PetscInt dim, const PetscFVCellGeom *cg, const PetscInt *uOff, const PetscScalar *u, const PetscScalar *const *gradU,
-                                                                              const PetscInt *aOff, const PetscScalar *a, const PetscScalar *const *gradA, PetscScalar *f, void *ctx) {
+PetscErrorCode ablate::finiteVolume::processes::Gravity::ComputeGravitySource(PetscInt dim, PetscReal time, const PetscFVCellGeom *cg, const PetscInt *uOff, const PetscScalar *u,
+                                                                              const PetscScalar *const *gradU, const PetscInt *aOff, const PetscScalar *a, const PetscScalar *const *gradA,
+                                                                              PetscScalar *f, void *ctx) {
     PetscFunctionBeginUser;
     const int EULER_FIELD = 0;
     auto gravityProcess = (ablate::finiteVolume::processes::Gravity *)ctx;

--- a/ablateLibrary/finiteVolume/processes/gravity.hpp
+++ b/ablateLibrary/finiteVolume/processes/gravity.hpp
@@ -25,8 +25,8 @@ class Gravity : public FlowProcess {
      * private function to compute gravity source
      * @return
      */
-    static PetscErrorCode ComputeGravitySource(PetscInt dim, const PetscFVCellGeom* cg, const PetscInt uOff[], const PetscScalar u[], const PetscScalar* const gradU[], const PetscInt aOff[],
-                                               const PetscScalar a[], const PetscScalar* const gradA[], PetscScalar f[], void* ctx);
+    static PetscErrorCode ComputeGravitySource(PetscInt dim, PetscReal time, const PetscFVCellGeom* cg, const PetscInt uOff[], const PetscScalar u[], const PetscScalar* const gradU[],
+                                               const PetscInt aOff[], const PetscScalar a[], const PetscScalar* const gradA[], PetscScalar f[], void* ctx);
 
    public:
     explicit Gravity(std::vector<double> gravityVector);

--- a/tests/integrationTests/inputs/compressibleFlow/extraVariableTransport.yaml
+++ b/tests/integrationTests/inputs/compressibleFlow/extraVariableTransport.yaml
@@ -48,7 +48,7 @@ timestepper:
         - !ablate::mathFunctions::geom::Sphere
           center: [ .25, .25 ]
           radius: .25
-          insideValues: [ 1.5 ]
+          insideValues:  1.5 
 solver: !ablate::finiteVolume::CompressibleFlowSolver
   id: evExample
   parameters:
@@ -61,6 +61,13 @@ solver: !ablate::finiteVolume::CompressibleFlowSolver
     k: 1E-4
     mu: 1E-4
   eos: *eos
+  additionalProcesses:
+    - !ablate::finiteVolume::processes::ArbitrarySource
+      densityEV:
+        !ablate::mathFunctions::geom::Sphere
+        radius: .1
+        center: [0.75, 0.75]
+        insideValues: "0.0, 100"
   boundaryConditions:
     - !ablate::finiteVolume::boundaryConditions::EssentialGhost
       boundaryName: "walls"
@@ -70,8 +77,6 @@ solver: !ablate::finiteVolume::CompressibleFlowSolver
       boundaryName: "walls"
       labelIds: [ 1, 2, 3, 4 ]
       boundaryValue: *densityEVFlowFieldState
-
-  
   monitors:
     - !ablate::monitors::TimeStepMonitor
 


### PR DESCRIPTION
Adds support for arbitrary math functions to the FVM point source functions through the input file and closes #211 

An example of this new feature can be found tests/integrationTests/inputs/compressibleFlow/extraVariableTransport.yaml

```yaml
  additionalProcesses:
    - !ablate::finiteVolume::processes::ArbitrarySource
      densityEV:
        !ablate::mathFunctions::geom::Sphere
        radius: .1
        center: [0.75, 0.75]
        insideValues: "0.0, 100"
```