### PR TITLE
Corrected two phase fluxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.8.1)
+project(ablateLibrary VERSION 0.8.2)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/ablateLibrary/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/ablateLibrary/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -177,7 +177,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Compress
     // Calculate total flux
     PetscReal alphaMin = PetscMin(alphaR, alphaL);
     PetscReal alphaDif = PetscAbs(alphaL - alphaR);
-    PetscReal alphaLiq = 1-alphaMin-alphaDif;
+    PetscReal alphaLiq = 1 - alphaMin - alphaDif;
     flux[CompressibleFlowFields::RHO] = (massFluxGG * areaMag * alphaMin) + (massFluxGL * areaMag * alphaDif) + (massFluxLL * areaMag * (1 - alphaMin - alphaDif));
 
     PetscReal velMagL = MagVector(dim, velocityL);
@@ -188,14 +188,14 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Compress
         flux[CompressibleFlowFields::RHOE] = (HG_L * massFluxGG * areaMag * alphaMin);
 
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] = velocityL[n] * areaMag * (massFluxGG * alphaMin) + (p12GG*alphaMin) * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] = velocityL[n] * areaMag * (massFluxGG * alphaMin) + (p12GG * alphaMin) * fg->normal[n];
         }
     } else if (directionG == fluxCalculator::RIGHT) {
         PetscReal HG_R = internalEnergyG_R + velMagR * velMagR / 2.0 + p12GG / densityG_R;
         flux[CompressibleFlowFields::RHOE] = (HG_R * massFluxGG * areaMag * alphaMin);
 
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] = velocityR[n] * areaMag * (massFluxGG * alphaMin) + (p12GG*alphaMin) * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] = velocityR[n] * areaMag * (massFluxGG * alphaMin) + (p12GG * alphaMin) * fg->normal[n];
         }
     } else {
         PetscReal HG_L = internalEnergyG_L + velMagL * velMagL / 2.0 + p12GG / densityG_L;
@@ -212,14 +212,14 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Compress
         flux[CompressibleFlowFields::RHOE] += (HL_L * massFluxLL * areaMag * alphaLiq);
 
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] += velocityL[n] * areaMag * (massFluxLL * alphaLiq) + (p12LL*alphaLiq) * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] += velocityL[n] * areaMag * (massFluxLL * alphaLiq) + (p12LL * alphaLiq) * fg->normal[n];
         }
     } else if (directionL == fluxCalculator::RIGHT) {
         PetscReal HL_R = internalEnergyL_R + velMagR * velMagR / 2.0 + p12LL / densityL_R;
         flux[CompressibleFlowFields::RHOE] += (HL_R * massFluxLL * areaMag * alphaLiq);
 
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] += velocityR[n] * areaMag * (massFluxLL * alphaLiq) + (p12LL*alphaLiq) * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] += velocityR[n] * areaMag * (massFluxLL * alphaLiq) + (p12LL * alphaLiq) * fg->normal[n];
         }
     } else {
         PetscReal HL_L = internalEnergyL_L + velMagL * velMagL / 2.0 + p12LL / densityL_L;
@@ -246,7 +246,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Compress
         flux[CompressibleFlowFields::RHOE] += (HGL_L * massFluxGL * areaMag * alphaDif);
 
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] += velocityL[n] * areaMag * (massFluxGL * alphaDif) + (p12GL*alphaDif) * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] += velocityL[n] * areaMag * (massFluxGL * alphaDif) + (p12GL * alphaDif) * fg->normal[n];
         }
     } else if (directionGL == fluxCalculator::RIGHT) {
         PetscReal HGL_R;
@@ -263,7 +263,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Compress
         flux[CompressibleFlowFields::RHOE] += (HGL_R * massFluxGL * areaMag * alphaDif);
 
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] += velocityR[n] * areaMag * (massFluxGL * alphaDif) + (p12GL*alphaDif) * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] += velocityR[n] * areaMag * (massFluxGL * alphaDif) + (p12GL * alphaDif) * fg->normal[n];
         }
     } else {
         PetscReal HGL_L;
@@ -291,8 +291,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Compress
 
         flux[CompressibleFlowFields::RHOE] += (0.5 * (HGL_L + HGL_R) * massFluxGL * areaMag * alphaDif);
         for (PetscInt n = 0; n < dim; n++) {
-            flux[CompressibleFlowFields::RHOU + n] +=
-                0.5 * (velocityL[n] + velocityR[n]) * areaMag * (massFluxGL * alphaDif) + (p12GL*alphaDif)  * fg->normal[n];
+            flux[CompressibleFlowFields::RHOU + n] += 0.5 * (velocityL[n] + velocityR[n]) * areaMag * (massFluxGL * alphaDif) + (p12GL * alphaDif) * fg->normal[n];
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
+#include <time.h>
 #include <fstream>
 #include <iostream>
-#include <time.h>
 #include <memory>
 #include <parameters/petscPrefixOptions.hpp>
 #include <utilities/fileUtility.hpp>
@@ -8,8 +8,8 @@
 #include "builder.hpp"
 #include "environment/runEnvironment.hpp"
 #include "listing.hpp"
-#include "yamlParser.hpp"
 #include "utilities/petscError.hpp"
+#include "yamlParser.hpp"
 
 using namespace ablate;
 
@@ -110,6 +110,6 @@ int main(int argc, char** args) {
 
     // output runtime
     clock_t stop = clock();
-    double elapsed = (double) (stop - start) / CLOCKS_PER_SEC;
+    double elapsed = (double)(stop - start) / CLOCKS_PER_SEC;
     std::cout << "Runtime: " << elapsed << " sec" << std::endl;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,3 @@
-#include <time.h>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -16,9 +15,6 @@ using namespace ablate;
 const char* replacementInputPrefix = "-yaml::";
 
 int main(int argc, char** args) {
-    // start clock time
-    clock_t start = clock();
-
     // initialize petsc and mpi
     PetscInitialize(&argc, &args, NULL, NULL) >> checkError;
 
@@ -107,9 +103,4 @@ int main(int argc, char** args) {
         }
     }
     PetscFinalize() >> checkError;
-
-    // output runtime
-    clock_t stop = clock();
-    double elapsed = (double)(stop - start) / CLOCKS_PER_SEC;
-    std::cout << "Runtime: " << elapsed << " sec" << std::endl;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <iostream>
+#include <time.h>
 #include <memory>
 #include <parameters/petscPrefixOptions.hpp>
 #include <utilities/fileUtility.hpp>
@@ -15,6 +16,9 @@ using namespace ablate;
 const char* replacementInputPrefix = "-yaml::";
 
 int main(int argc, char** args) {
+    // start clock time
+    clock_t start = clock();
+
     // initialize petsc and mpi
     PetscInitialize(&argc, &args, NULL, NULL) >> checkError;
 
@@ -103,4 +107,9 @@ int main(int argc, char** args) {
         }
     }
     PetscFinalize() >> checkError;
+
+    // output runtime
+    clock_t stop = clock();
+    double elapsed = (double) (stop - start) / CLOCKS_PER_SEC;
+    std::cout << "Runtime: " << elapsed << " sec" << std::endl;
 }


### PR DESCRIPTION
Corrects the upwinding for the stratified flow model, using the upwind direction for each section of the interface instead of one for the whole face.  Also uses the interface pressure instead of upwind pressure for more accurate calculations.  Adds printout of total runtime of code.