### PR TITLE
chemistry monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.9.28)
+project(ablateLibrary VERSION 0.9.29)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/chemistry/CMakeLists.txt
+++ b/src/chemistry/CMakeLists.txt
@@ -1,7 +1,10 @@
 target_sources(ablateLibrary
         PRIVATE
         chemTabModel.cpp
+        mixtureFractionCalculator.cpp
+
         PUBLIC
         chemistryModel.hpp
         chemTabModel.hpp
+        mixtureFractionCalculator.hpp
         )

--- a/src/chemistry/mixtureFractionCalculator.cpp
+++ b/src/chemistry/mixtureFractionCalculator.cpp
@@ -1,0 +1,82 @@
+#include "mixtureFractionCalculator.hpp"
+#include "utilities/mathUtilities.hpp"
+
+ablate::chemistry::MixtureFractionCalculator::MixtureFractionCalculator(const std::shared_ptr<ablate::eos::EOS>& eosIn, std::map<std::string, double> massFractionsFuel,
+                                                                        std::map<std::string, double> massFractionsOxidizer, const std::vector<std::string>& trackingElementsIn)
+    : eos(std::dynamic_pointer_cast<eos::TChem>(eosIn)), trackingElements(trackingElementsIn.empty() ? std::vector<std::string>{"C", "H"} : trackingElementsIn) {
+    // make sure that the eos is set
+    if (!std::dynamic_pointer_cast<eos::TChem>(eosIn)) {
+        throw std::invalid_argument("ablate::chemistry::MixtureFractionCalculator only accepts EOS of type eos::TChem");
+    }
+
+    // make sure that the massFractionsOxidizer sums to 1.0
+    double massFractionsFuelSum = 0.0;
+    for (const auto& [sp, yi] : massFractionsFuel) {
+        massFractionsFuelSum += yi;
+    }
+    if (!ablate::utilities::MathUtilities::Equals(1.0, massFractionsFuelSum)) {
+        throw std::invalid_argument("The fuel massFractions (" + std::to_string(massFractionsFuelSum) +
+                                    ") provided to ablate::chemistry::MixtureFractionCalculator::MixtureFractionCalculator does not sum to 1.0");
+    }
+
+    double massFractionsOxidizerSum = 0.0;
+    for (const auto& [sp, yi] : massFractionsOxidizer) {
+        massFractionsOxidizerSum += yi;
+    }
+    if (!ablate::utilities::MathUtilities::Equals(1.0, massFractionsOxidizerSum)) {
+        throw std::invalid_argument("The oxidizer massFractions (" + std::to_string(massFractionsOxidizerSum) +
+                                    ") provided to ablate::chemistry::MixtureFractionCalculator::MixtureFractionCalculator does not sum to 1.0");
+    }
+
+    // first run a sanity check to make sure that the sum of atomic masses for every molecule = MW of this molecule reported back from eos.lookupMW.
+    // This check should avoid headaches when mapping species to mixture fraction.
+    auto speciesElementInformation = eos->GetSpeciesElementalInformation();
+    auto elementInformation = eos->GetElementInformation();
+    auto speciesMolecularMass = eos->GetSpeciesMolecularMass();
+    for (const auto& [species, info] : speciesElementInformation) {
+        double sum = 0.0;
+        for (const auto& [e, count] : info) {
+            sum += count * elementInformation[e];
+        }
+
+        if (!ablate::utilities::MathUtilities::Equals(sum, speciesMolecularMass[species])) {
+            throw std::invalid_argument("Problem in ablate::chemistry::MixtureFractionCalculator. Sum of all mixFracMassCoeff =/= 1 for " + species);
+        }
+    }
+
+    // make sure that each trackingElements is in the elementInformation
+    for (const auto& trackingElement : trackingElements) {
+        if (!elementInformation.count(trackingElement)) {
+            throw std::invalid_argument("The tracking element " + trackingElement + " does not exist in the equation of state");
+        }
+    }
+
+    // next determine mixFracMassCoeff
+    const auto& species = eos->GetSpecies();
+    zMixCoefficients.resize(species.size(), 0.0);
+    for (std::size_t s = 0; s < species.size(); s++) {
+        const auto& speciesName = species[s];
+        const auto& speciesElement = speciesElementInformation[speciesName];
+        for (const auto& element : trackingElements) {
+            zMixCoefficients[s] += speciesElement.at(element) * elementInformation[element] / speciesMolecularMass[speciesName];
+        }
+    }
+    // Compute reference values
+    zMixFuel = 0.0;
+    zMixOxidizer = 0.0;
+    for (std::size_t s = 0; s < species.size(); s++) {
+        zMixFuel += zMixCoefficients[s] * massFractionsFuel[species[s]];
+        zMixOxidizer += zMixCoefficients[s] * massFractionsOxidizer[species[s]];
+    }
+}
+
+ablate::chemistry::MixtureFractionCalculator::MixtureFractionCalculator(const std::shared_ptr<ablate::eos::EOS>& eos, const std::shared_ptr<ablate::parameters::Parameters>& massFractionsFuel,
+                                                                        const std::shared_ptr<ablate::parameters::Parameters>& massFractionsOxidizer, const std::vector<std::string>& trackingElements)
+    : MixtureFractionCalculator(eos, massFractionsFuel->ToMap<double>(), massFractionsOxidizer->ToMap<double>(), trackingElements) {}
+
+#include "registrar.hpp"
+REGISTER(ablate::chemistry::MixtureFractionCalculator, ablate::chemistry::MixtureFractionCalculator,
+         "Calculate mixture fraction given a list of species using elemental species based on Bilger's (1980) definition of mixture fraction",
+         ARG(ablate::eos::EOS, "eos", "The eos with the list of species"), ARG(ablate::parameters::Parameters, "massFractionsFuel", "The initial mass fractions of fuel"),
+         ARG(ablate::parameters::Parameters, "massFractionsOxidizer", "The initial mass fractions of oxidizer"),
+         OPT(std::vector<std::string>, "trackingElements", "the elements used to element list of the elements you want to track that are in the fuel (defaults to C/H)"));

--- a/src/chemistry/mixtureFractionCalculator.hpp
+++ b/src/chemistry/mixtureFractionCalculator.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 #include "eos/tChem.hpp"
-#include "parameters/parameters.hpp"
+#include "mathFunctions/fieldFunction.hpp"
 
 namespace ablate::chemistry {
 
@@ -29,6 +29,14 @@ class MixtureFractionCalculator {
     //! the mixture fraction coefficients for each of the species in the equation of state
     std::vector<double> zMixCoefficients;
 
+    /**
+     * static function to help convert from FieldFunction to map
+     * @param eos
+     * @param massFractionsFuel
+     * @return
+     */
+    static std::map<std::string, double> ToMassFractionMap(const std::shared_ptr<ablate::eos::EOS>& eos,  const std::shared_ptr<ablate::mathFunctions::FieldFunction>& massFractions);
+
    public:
     /**
      * Create the MixtureFractionCalculator to compute the zMixFuel, zMixOxidizer, and trackingElements
@@ -41,14 +49,15 @@ class MixtureFractionCalculator {
                               const std::vector<std::string>& trackingElements = {});
 
     /**
-     * Create the MixtureFractionCalculator to compute the zMixFuel, zMixOxidizer, and trackingElements using parameters
+     * Create the MixtureFractionCalculator to compute the zMixFuel, zMixOxidizer, and trackingElements using field functions.  The point is evaluated at [0, 0, 0] with t = 0;
+     * This is used to allow reuse of field function setup in input files
      * @param eos The equation of state must be tChem
      * @param massFractionsFuel
      * @param massFractionsOxidizer
      * @param trackingElements defaults to C & H
      */
-    MixtureFractionCalculator(const std::shared_ptr<ablate::eos::EOS>& eos, const std::shared_ptr<ablate::parameters::Parameters>& massFractionsFuel,
-                              const std::shared_ptr<ablate::parameters::Parameters>& massFractionsOxidizer, const std::vector<std::string>& trackingElements = {});
+    MixtureFractionCalculator(const std::shared_ptr<ablate::eos::EOS>& eos, const std::shared_ptr<ablate::mathFunctions::FieldFunction>& massFractionsFuel,
+                              const std::shared_ptr<ablate::mathFunctions::FieldFunction>& massFractionsOxidizer, const std::vector<std::string>& trackingElements = {});
     /**
      * Computes the mixture fraction for a give set of Yi's
      * @tparam T
@@ -63,6 +72,12 @@ class MixtureFractionCalculator {
         }
         return (zMix - zMixOxidizer) / (zMixFuel - zMixOxidizer);
     }
+
+    /**
+     * Return accesses the base eos
+     * @return
+     */
+    std::shared_ptr<ablate::eos::TChem> GetEos() { return eos; }
 };
 
 }  // namespace ablate::chemistry

--- a/src/chemistry/mixtureFractionCalculator.hpp
+++ b/src/chemistry/mixtureFractionCalculator.hpp
@@ -1,0 +1,69 @@
+#ifndef ABLATELIBRARY_MIXTUREFRACTIONCALCULATOR_HPP
+#define ABLATELIBRARY_MIXTUREFRACTIONCALCULATOR_HPP
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+#include "eos/tChem.hpp"
+#include "parameters/parameters.hpp"
+
+namespace ablate::chemistry {
+
+/**
+ * Calculate mixture fraction given a list of species using elemental species based on Bilger's (1980) definition of mixture fraction Zeta =
+ * (Zi-Zi,ox)/(Zi,f-Zi,ox) which is the normalized elemental mass fraction of any element where f denotes the fuel stream and ox denotes the oxidizer
+ * stream.
+ */
+class MixtureFractionCalculator {
+   private:
+    //! the reference equation of state
+    const std::shared_ptr<ablate::eos::TChem> eos;
+
+    //! the elements used to element list of the elements you want to track that are in the fuel (defaults to C/H)
+    const std::vector<std::string> trackingElements;
+
+    //! the mixture fraction of pure fuel and pure oxidizer
+    double zMixFuel, zMixOxidizer;
+
+    //! the mixture fraction coefficients for each of the species in the equation of state
+    std::vector<double> zMixCoefficients;
+
+   public:
+    /**
+     * Create the MixtureFractionCalculator to compute the zMixFuel, zMixOxidizer, and trackingElements
+     * @param eos The equation of state must be tChem
+     * @param massFractionsFuel
+     * @param massFractionsOxidizer
+     * @param trackingElements defaults to C & H
+     */
+    MixtureFractionCalculator(const std::shared_ptr<ablate::eos::EOS>& eos, std::map<std::string, double> massFractionsFuel, std::map<std::string, double> massFractionsOxidizer,
+                              const std::vector<std::string>& trackingElements = {});
+
+    /**
+     * Create the MixtureFractionCalculator to compute the zMixFuel, zMixOxidizer, and trackingElements using parameters
+     * @param eos The equation of state must be tChem
+     * @param massFractionsFuel
+     * @param massFractionsOxidizer
+     * @param trackingElements defaults to C & H
+     */
+    MixtureFractionCalculator(const std::shared_ptr<ablate::eos::EOS>& eos, const std::shared_ptr<ablate::parameters::Parameters>& massFractionsFuel,
+                              const std::shared_ptr<ablate::parameters::Parameters>& massFractionsOxidizer, const std::vector<std::string>& trackingElements = {});
+    /**
+     * Computes the mixture fraction for a give set of Yi's
+     * @tparam T
+     * @param yi.  The yi's are assumed to be of length/order of the species in the eos
+     * @return
+     */
+    template <class T>
+    inline T Calculate(T* yi) const {
+        double zMix = 0.;
+        for (std::size_t s = 0; s < zMixCoefficients.size(); s++) {
+            zMix += zMixCoefficients[s] * yi[s];
+        }
+        return (zMix - zMixOxidizer) / (zMixFuel - zMixOxidizer);
+    }
+};
+
+}  // namespace ablate::chemistry
+#endif  // ABLATELIBRARY_MIXTUREFRACTIONCALCULATOR_HPP

--- a/src/chemistry/mixtureFractionCalculator.hpp
+++ b/src/chemistry/mixtureFractionCalculator.hpp
@@ -35,7 +35,7 @@ class MixtureFractionCalculator {
      * @param massFractionsFuel
      * @return
      */
-    static std::map<std::string, double> ToMassFractionMap(const std::shared_ptr<ablate::eos::EOS>& eos,  const std::shared_ptr<ablate::mathFunctions::FieldFunction>& massFractions);
+    static std::map<std::string, double> ToMassFractionMap(const std::shared_ptr<ablate::eos::EOS>& eos, const std::shared_ptr<ablate::mathFunctions::FieldFunction>& massFractions);
 
    public:
     /**

--- a/src/domain/CMakeLists.txt
+++ b/src/domain/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(ablateLibrary
         fieldDescription.cpp
         boxMeshBoundaryCells.cpp
         cadFile.cpp
+        dmTransfer.cpp
 
         PUBLIC
         domain.hpp
@@ -27,6 +28,7 @@ target_sources(ablateLibrary
         fieldDescriptor.hpp
         boxMeshBoundaryCells.hpp
         cadFile.hpp
+        dmTransfer.hpp
         )
 
 add_subdirectory(modifiers)

--- a/src/domain/dmTransfer.cpp
+++ b/src/domain/dmTransfer.cpp
@@ -1,0 +1,21 @@
+#include "dmTransfer.hpp"
+
+#include <utility>
+#include "utilities/petscError.hpp"
+
+static std::string getPetscObjectName(DM dm) {
+    const char* name;
+    PetscObjectName((PetscObject)dm) >> ablate::checkError;
+    PetscObjectGetName((PetscObject)dm, &name) >> ablate::checkError;
+    return {name};
+}
+
+ablate::domain::DMTransfer::DMTransfer(DM dm, std::vector<std::shared_ptr<FieldDescriptor>> fieldDescriptors, std::vector<std::shared_ptr<modifiers::Modifier>> modifiers,
+                                       std::shared_ptr<parameters::Parameters> options)
+    : ablate::domain::Domain(dm, getPetscObjectName(dm), std::move(fieldDescriptors), modifiers, options) {}
+
+ablate::domain::DMTransfer::~DMTransfer() {
+    if (dm) {
+        DMDestroy(&dm) >> checkError;
+    }
+}

--- a/src/domain/dmTransfer.cpp
+++ b/src/domain/dmTransfer.cpp
@@ -12,7 +12,7 @@ static std::string getPetscObjectName(DM dm) {
 
 ablate::domain::DMTransfer::DMTransfer(DM dm, std::vector<std::shared_ptr<FieldDescriptor>> fieldDescriptors, std::vector<std::shared_ptr<modifiers::Modifier>> modifiers,
                                        std::shared_ptr<parameters::Parameters> options)
-    : ablate::domain::Domain(dm, getPetscObjectName(dm), std::move(fieldDescriptors), modifiers, options) {}
+    : ablate::domain::Domain(dm, getPetscObjectName(dm), std::move(fieldDescriptors), modifiers, options, false /*prevent set from options*/) {}
 
 ablate::domain::DMTransfer::~DMTransfer() {
     if (dm) {

--- a/src/domain/dmTransfer.hpp
+++ b/src/domain/dmTransfer.hpp
@@ -9,7 +9,7 @@ namespace ablate::domain {
 class DMTransfer : public ablate::domain::Domain {
    public:
     explicit DMTransfer(DM dm, std::vector<std::shared_ptr<FieldDescriptor>> fieldDescriptors, std::vector<std::shared_ptr<modifiers::Modifier>> modifiers = {},
-                       std::shared_ptr<parameters::Parameters> options = {});
+                        std::shared_ptr<parameters::Parameters> options = {});
     ~DMTransfer() override;
 };
 }  // namespace ablate::domain

--- a/src/domain/dmTransfer.hpp
+++ b/src/domain/dmTransfer.hpp
@@ -1,0 +1,17 @@
+#ifndef ABLATELIBRARY_DMTRANSFER_HPP
+#define ABLATELIBRARY_DMTRANSFER_HPP
+#include "domain.hpp"
+
+namespace ablate::domain {
+/**
+ * Transfer ownership ownership of the specified domain and destroy it when complete.
+ */
+class DMTransfer : public ablate::domain::Domain {
+   public:
+    explicit DMTransfer(DM dm, std::vector<std::shared_ptr<FieldDescriptor>> fieldDescriptors, std::vector<std::shared_ptr<modifiers::Modifier>> modifiers = {},
+                       std::shared_ptr<parameters::Parameters> options = {});
+    ~DMTransfer() override;
+};
+}  // namespace ablate::domain
+
+#endif  // ABLATELIBRARY_DMREFERENCE_HPP

--- a/src/domain/domain.cpp
+++ b/src/domain/domain.cpp
@@ -10,7 +10,7 @@
 #include "utilities/petscOptions.hpp"
 
 ablate::domain::Domain::Domain(DM dmIn, std::string name, std::vector<std::shared_ptr<FieldDescriptor>> fieldDescriptorsIn, std::vector<std::shared_ptr<modifiers::Modifier>> modifiersIn,
-                               const std::shared_ptr<parameters::Parameters>& options)
+                               const std::shared_ptr<parameters::Parameters>& options, bool setFromOptions)
     : dm(dmIn), name(std::move(name)), comm(PetscObjectComm((PetscObject)dm)), fieldDescriptors(std::move(fieldDescriptorsIn)), solGlobalField(nullptr), modifiers(std::move(modifiersIn)) {
     // if provided, convert options to a petscOptions
     if (options) {
@@ -20,8 +20,9 @@ ablate::domain::Domain::Domain(DM dmIn, std::string name, std::vector<std::share
 
     // Apply petsc options to the domain
     PetscObjectSetOptions((PetscObject)dm, petscOptions) >> checkError;
-    DMSetFromOptions(dm) >> checkError;
-
+    if (setFromOptions) {
+        DMSetFromOptions(dm) >> checkError;
+    }
     // update the dm with the modifiers
     for (auto& modifier : modifiers) {
         modifier->Modify(dm);

--- a/src/domain/domain.hpp
+++ b/src/domain/domain.hpp
@@ -60,7 +60,7 @@ class Domain {
     PetscOptions petscOptions = nullptr;
 
    public:
-    [[nodiscard]] std::string GetName() const { return name; }
+    [[nodiscard]] const std::string& GetName() const { return name; }
 
     inline DM& GetDM() noexcept { return dm; }
 
@@ -78,7 +78,12 @@ class Domain {
 
     [[nodiscard]] PetscInt GetDimensions() const noexcept;
 
-    void InitializeSubDomains(const std::vector<std::shared_ptr<solver::Solver>>& solvers, const std::vector<std::shared_ptr<mathFunctions::FieldFunction>>& initializations,
+    /**
+     * Setup the local data storage
+     * @param solvers
+     * @param initializations
+     */
+    void InitializeSubDomains(const std::vector<std::shared_ptr<solver::Solver>>& solvers = {}, const std::vector<std::shared_ptr<mathFunctions::FieldFunction>>& initializations = {},
                               const std::vector<std::shared_ptr<mathFunctions::FieldFunction>>& = {});
 
     /**

--- a/src/domain/domain.hpp
+++ b/src/domain/domain.hpp
@@ -26,7 +26,7 @@ class SubDomain;
 class Domain {
    protected:
     Domain(DM dm, std::string name, std::vector<std::shared_ptr<FieldDescriptor>>, std::vector<std::shared_ptr<modifiers::Modifier>> modifiers,
-           const std::shared_ptr<parameters::Parameters>& options = {});
+           const std::shared_ptr<parameters::Parameters>& options = {}, bool setFromOptions = true);
     virtual ~Domain();
 
     // The primary dm

--- a/src/domain/subDomain.cpp
+++ b/src/domain/subDomain.cpp
@@ -845,10 +845,10 @@ bool ablate::domain::SubDomain::CheckSolution() {
 void ablate::domain::SubDomain::CreateEmptySubDM(DM* inDM, std::shared_ptr<domain::Region> region) {
     DMLabel subDmLabel = nullptr;
     PetscInt subDmValue;
-    if(region) {
+    if (region) {
         // Get the region info from the provided region
         domain::Region::GetLabel(region, GetDM(), subDmLabel, subDmValue);
-    }else{
+    } else {
         // Grab it from the domain itself
         subDmLabel = GetLabel();
         subDmValue = labelValue;

--- a/src/domain/subDomain.cpp
+++ b/src/domain/subDomain.cpp
@@ -842,9 +842,19 @@ bool ablate::domain::SubDomain::CheckSolution() {
     return (bool)globalFailedPoints;
 }
 
-void ablate::domain::SubDomain::CreateEmptySubDM(DM* inDM) {
-    if (GetLabel()) {
-        DMPlexFilter(GetDM(), GetLabel(), 1, inDM);
+void ablate::domain::SubDomain::CreateEmptySubDM(DM* inDM, std::shared_ptr<domain::Region> region) {
+    DMLabel subDmLabel = nullptr;
+    PetscInt subDmValue;
+    if(region) {
+        // Get the region info from the provided region
+        domain::Region::GetLabel(region, GetDM(), subDmLabel, subDmValue);
+    }else{
+        // Grab it from the domain itself
+        subDmLabel = GetLabel();
+        subDmValue = labelValue;
+    }
+    if (subDmLabel) {
+        DMPlexFilter(GetDM(), subDmLabel, subDmValue, inDM);
     } else {
         DMClone(GetDM(), inDM);
     }

--- a/src/domain/subDomain.hpp
+++ b/src/domain/subDomain.hpp
@@ -389,7 +389,7 @@ class SubDomain : public io::Serializable {
      * This checks for whether the label describing the subdomain exists. If it does, use DMPlexFilter. If not, use DMClone to return new DM.
      * @param inDM
      */
-    void CreateEmptySubDM(DM* inDM);
+    void CreateEmptySubDM(DM* inDM, std::shared_ptr<domain::Region> region = {});
 };
 
 }  // namespace ablate::domain

--- a/src/eos/tChem.hpp
+++ b/src/eos/tChem.hpp
@@ -85,6 +85,24 @@ class TChem : public EOS {
     [[nodiscard]] const std::vector<std::string>& GetSpecies() const override { return species; }
 
     /**
+     * Returns all elements tracked in this mechanism and their molecular mass
+     * @return
+     */
+    [[nodiscard]] std::map<std::string, double> GetElementInformation() const;
+
+    /**
+     * no. of atoms of each element in each species
+     * @return
+     */
+    [[nodiscard]] std::map<std::string, std::map<std::string, int>> GetSpeciesElementalInformation() const;
+
+    /**
+     * the MW of each species
+     * @return
+     */
+    [[nodiscard]] std::map<std::string, double> GetSpeciesMolecularMass() const;
+
+    /**
      * Print the details of this eos
      * @param stream
      */

--- a/src/finiteVolume/finiteVolumeSolver.hpp
+++ b/src/finiteVolume/finiteVolumeSolver.hpp
@@ -11,6 +11,7 @@
 #include "solver/cellSolver.hpp"
 #include "solver/solver.hpp"
 #include "solver/timeStepper.hpp"
+#include "utilities/vectorUtilities.hpp"
 
 namespace ablate::finiteVolume {
 
@@ -174,6 +175,16 @@ class FiniteVolumeSolver : public solver::CellSolver, public solver::RHSFunction
      * @param points
      */
     void GetCellRangeWithoutGhost(solver::Range& faceRange) const;
+
+    /**
+     * Returns first instance of process of type specifed
+     * @tparam T
+     * @return
+     */
+    template <class T>
+    std::shared_ptr<T> FindProcess(){
+        return utilities::VectorUtilities::Find<T>(processes);
+    }
 };
 }  // namespace ablate::finiteVolume
 

--- a/src/finiteVolume/finiteVolumeSolver.hpp
+++ b/src/finiteVolume/finiteVolumeSolver.hpp
@@ -182,7 +182,7 @@ class FiniteVolumeSolver : public solver::CellSolver, public solver::RHSFunction
      * @return
      */
     template <class T>
-    std::shared_ptr<T> FindProcess(){
+    std::shared_ptr<T> FindProcess() {
         return utilities::VectorUtilities::Find<T>(processes);
     }
 };

--- a/src/finiteVolume/processes/tChemReactions.cpp
+++ b/src/finiteVolume/processes/tChemReactions.cpp
@@ -5,7 +5,7 @@
 #include "utilities/petscError.hpp"
 #include "utilities/vectorUtilities.hpp"
 
-ablate::finiteVolume::processes::TChemReactions::TChemReactions(std::shared_ptr<eos::EOS> eosIn, std::shared_ptr<ablate::parameters::Parameters> options)
+ablate::finiteVolume::processes::TChemReactions::TChemReactions(const std::shared_ptr<eos::EOS>& eosIn, const std::shared_ptr<ablate::parameters::Parameters>& options)
     : eos(std::dynamic_pointer_cast<eos::TChem>(eosIn)), numberSpecies(eosIn->GetSpecies().size()) {
     // make sure that the eos is set
     if (!std::dynamic_pointer_cast<eos::TChem>(eosIn)) {
@@ -28,7 +28,7 @@ ablate::finiteVolume::processes::TChemReactions::TChemReactions(std::shared_ptr<
         maxAttempts = options->Get("maxAttempts", maxAttempts);
     }
 }
-ablate::finiteVolume::processes::TChemReactions::~TChemReactions() {}
+ablate::finiteVolume::processes::TChemReactions::~TChemReactions() = default;
 
 void ablate::finiteVolume::processes::TChemReactions::Setup(ablate::finiteVolume::FiniteVolumeSolver& flow) {
     // Before each step, compute the source term over the entire dt
@@ -368,6 +368,10 @@ PetscErrorCode ablate::finiteVolume::processes::TChemReactions::AddChemistrySour
     PetscCall(VecRestoreArray(locFVec, &fArray));
 
     PetscFunctionReturn(0);
+}
+
+void ablate::finiteVolume::processes::TChemReactions::AddChemistrySourceToFlow(const FiniteVolumeSolver& solver, Vec locFVec) {
+    AddChemistrySourceToFlow(solver, solver.GetSubDomain().GetDM(), NAN, nullptr, locFVec, this) >> checkError;
 }
 
 #include "registrar.hpp"

--- a/src/finiteVolume/processes/tChemReactions.hpp
+++ b/src/finiteVolume/processes/tChemReactions.hpp
@@ -38,7 +38,7 @@ class TChemReactions : public Process {
 
     // the time advance information
     time_advance_type_1d_view timeAdvanceDevice;
-    time_advance_type timeAdvanceDefault;
+    time_advance_type timeAdvanceDefault{};
 
     // store host/device memory for computing state
     real_type_1d_view internalEnergyRefDevice;
@@ -74,7 +74,7 @@ class TChemReactions : public Process {
     static PetscErrorCode AddChemistrySourceToFlow(const FiniteVolumeSolver &solver, DM dm, PetscReal time, Vec locX, Vec fVec, void *ctx);
 
    public:
-    explicit TChemReactions(std::shared_ptr<eos::EOS> eos, std::shared_ptr<ablate::parameters::Parameters> options = {});
+    explicit TChemReactions(const std::shared_ptr<eos::EOS>& eos, const std::shared_ptr<ablate::parameters::Parameters>& options = {});
     ~TChemReactions() override;
     /**
      * public function to link this process with the flow
@@ -87,6 +87,13 @@ class TChemReactions : public Process {
      * @param flow
      */
     void Initialize(ablate::finiteVolume::FiniteVolumeSolver &flow) override;
+
+    /**
+     * public function to copy the source terms to a locFVec
+     * @param solver
+     * @param fVec
+     */
+    void AddChemistrySourceToFlow(const FiniteVolumeSolver &solver, Vec locFVec);
 };
 }  // namespace ablate::finiteVolume::processes
 #endif

--- a/src/finiteVolume/processes/tChemReactions.hpp
+++ b/src/finiteVolume/processes/tChemReactions.hpp
@@ -74,7 +74,7 @@ class TChemReactions : public Process {
     static PetscErrorCode AddChemistrySourceToFlow(const FiniteVolumeSolver &solver, DM dm, PetscReal time, Vec locX, Vec fVec, void *ctx);
 
    public:
-    explicit TChemReactions(const std::shared_ptr<eos::EOS>& eos, const std::shared_ptr<ablate::parameters::Parameters>& options = {});
+    explicit TChemReactions(const std::shared_ptr<eos::EOS> &eos, const std::shared_ptr<ablate::parameters::Parameters> &options = {});
     ~TChemReactions() override;
     /**
      * public function to link this process with the flow

--- a/src/io/serializable.hpp
+++ b/src/io/serializable.hpp
@@ -1,6 +1,9 @@
 #ifndef ABLATELIBRARY_SERIALIZABLE_HPP
 #define ABLATELIBRARY_SERIALIZABLE_HPP
 
+#include <petsc.h>
+#include <string>
+
 namespace ablate::io {
 /**
  * This class gives the option to serialize/save restore.  A bool is used at startup to determine if it should be save/restored
@@ -12,13 +15,13 @@ class Serializable {
      * boolean used to determined if this object should be serialized at runtime
      * @return
      */
-    virtual bool Serialize() const { return true; }
+    [[nodiscard]] virtual bool Serialize() const { return true; }
 
     /**
      * only required function, returns the id of the object.  Should be unique for the simulation
      * @return
      */
-    virtual const std::string& GetId() const = 0;
+    [[nodiscard]] virtual const std::string& GetId() const = 0;
 
     /**
      * Save the state to the PetscViewer

--- a/src/mathFunctions/constantValue.hpp
+++ b/src/mathFunctions/constantValue.hpp
@@ -18,7 +18,7 @@ class ConstantValue : public MathFunction {
 
     explicit ConstantValue(std::vector<double> values);
 
-    double Eval(const double& x, const double& y, const double& z, const double& t) const override;
+    [[nodiscard]] double Eval(const double& x, const double& y, const double& z, const double& t) const override;
 
     double Eval(const double* xyz, const int& ndims, const double& t) const override;
 

--- a/src/monitors/CMakeLists.txt
+++ b/src/monitors/CMakeLists.txt
@@ -15,6 +15,9 @@ target_sources(ablateLibrary
         probes.cpp
         rocketMonitor.cpp
         turbFlowStats.cpp
+        fieldMonitor.cpp
+        mixtureFractionMonitor.cpp
+
         PUBLIC
         monitor.hpp
         fieldErrorMonitor.hpp
@@ -32,6 +35,8 @@ target_sources(ablateLibrary
         probes.hpp
         rocketMonitor.hpp
         turbFlowStats.hpp
+        fieldMonitor.hpp
+        mixtureFractionMonitor.hpp
         )
 
 add_subdirectory(logs)

--- a/src/monitors/fieldMonitor.cpp
+++ b/src/monitors/fieldMonitor.cpp
@@ -1,0 +1,39 @@
+#include "fieldMonitor.hpp"
+#include "domain/dmTransfer.hpp"
+
+void ablate::monitors::FieldMonitor::Register(std::string id, std::shared_ptr<solver::Solver> solverIn, std::vector<std::shared_ptr<domain::FieldDescriptor>> fieldDescriptors) {
+    // Set the local variables
+    ablate::monitors::Monitor::Register(solverIn);
+
+    // make sure that each of the fields is for the entire domain
+    for(const auto& fieldDescriptor: fieldDescriptors){
+        for(const auto& field: fieldDescriptor->GetFields()){
+            if(field->region != domain::Region::ENTIREDOMAIN){
+                throw std::invalid_argument("The ablate::monitors::FieldMonito requires all fields to be defined over the entire domain");
+            }
+        }
+    }
+
+
+    // Create a subDomain only over this solver region
+    DM subDm;
+    solverIn->GetSubDomain().CreateEmptySubDM(&subDm, solverIn->GetRegion());
+
+    // name the subDm
+    PetscObjectSetName((PetscObject)subDm, id.c_str()) >> checkError;
+
+    // Create a domain
+    monitorDomain = std::make_shared<ablate::domain::DMTransfer>(subDm, fieldDescriptors);
+
+    // Init the monitorDomain
+    monitorDomain->InitializeSubDomains({}, {});
+
+    // Get the subdomain for this domain.  There should only be one ds created
+    monitorSubDomain = monitorDomain->GetSubDomain(nullptr);
+
+    // remove the name for this vector
+    PetscObjectSetName((PetscObject)monitorSubDomain->GetSolutionVector(), "monitor") >> checkError;
+}
+
+void ablate::monitors::FieldMonitor::Save(PetscViewer viewer, PetscInt sequenceNumber, PetscReal time) { monitorSubDomain->Save(viewer, sequenceNumber, time); }
+void ablate::monitors::FieldMonitor::Restore(PetscViewer viewer, PetscInt sequenceNumber, PetscReal time) { monitorSubDomain->Restore(viewer, sequenceNumber, time); }

--- a/src/monitors/fieldMonitor.cpp
+++ b/src/monitors/fieldMonitor.cpp
@@ -6,14 +6,13 @@ void ablate::monitors::FieldMonitor::Register(std::string id, std::shared_ptr<so
     ablate::monitors::Monitor::Register(solverIn);
 
     // make sure that each of the fields is for the entire domain
-    for(const auto& fieldDescriptor: fieldDescriptors){
-        for(const auto& field: fieldDescriptor->GetFields()){
-            if(field->region != domain::Region::ENTIREDOMAIN){
+    for (const auto& fieldDescriptor : fieldDescriptors) {
+        for (const auto& field : fieldDescriptor->GetFields()) {
+            if (field->region != domain::Region::ENTIREDOMAIN) {
                 throw std::invalid_argument("The ablate::monitors::FieldMonito requires all fields to be defined over the entire domain");
             }
         }
     }
-
 
     // Create a subDomain only over this solver region
     DM subDm;

--- a/src/monitors/fieldMonitor.hpp
+++ b/src/monitors/fieldMonitor.hpp
@@ -1,0 +1,62 @@
+#ifndef ABLATELIBRARY_FIELDMONITOR_HPP
+#define ABLATELIBRARY_FIELDMONITOR_HPP
+
+#include <petsc.h>
+#include <vector>
+#include "io/serializable.hpp"
+#include "monitor.hpp"
+
+namespace ablate::monitors {
+
+/**
+ * An abstract class that provides support for creating, writing, and outputting new fields
+ */
+class FieldMonitor : public Monitor, public io::Serializable {
+   private:
+    // Reuse the domain object to set up a domain to hold the monitor vector/dm
+    std::shared_ptr<ablate::domain::Domain> monitorDomain = nullptr;
+
+   protected:
+    // Hold onto the subdomain for this monitor.  It should be over the entire monitorDomain
+    std::shared_ptr<ablate::domain::SubDomain> monitorSubDomain = nullptr;
+
+   public:
+    /**
+     * only required function, returns the id of the object.  Should be unique for the simulation
+     * @return
+     */
+    const std::string& GetId() const override { return monitorDomain->GetName(); }
+
+    /**
+     * In order to use the base class, the Register call must be overridden and Register(std::shared_ptr<solver::Solver> solverIn, std::vector<domain::FieldDescription> fields) must be called from the
+     * method
+     * @param solverIn
+     */
+    void Register(std::shared_ptr<solver::Solver> solverIn) override = 0;
+
+    /**
+     * In order to use the base class, the Register call must be overridden and
+     * @param solverIn
+     */
+    void Register(std::string id, std::shared_ptr<solver::Solver> solverIn, std::vector<std::shared_ptr<domain::FieldDescriptor>> fields);
+
+    /**
+     * Save the state to the PetscViewer
+     * @param viewer
+     * @param sequenceNumber
+     * @param time
+     */
+    void Save(PetscViewer viewer, PetscInt sequenceNumber, PetscReal time) override;
+
+    /**
+     * Restore the state from the PetscViewer
+     * @param viewer
+     * @param sequenceNumber
+     * @param time
+     */
+    void Restore(PetscViewer viewer, PetscInt sequenceNumber, PetscReal time) override;
+};
+
+}  // namespace ablate::monitors
+
+#endif  // ABLATELIBRARY_FIELDMONITOR_HPP

--- a/src/monitors/mixtureFractionMonitor.cpp
+++ b/src/monitors/mixtureFractionMonitor.cpp
@@ -1,0 +1,134 @@
+#include "mixtureFractionMonitor.hpp"
+
+#include <utility>
+#include "finiteVolume/compressibleFlowFields.hpp"
+
+ablate::monitors::MixtureFractionMonitor::MixtureFractionMonitor(std::shared_ptr<ablate::chemistry::MixtureFractionCalculator> mixtureFractionCalculator)
+    : mixtureFractionCalculator(std::move(std::move(mixtureFractionCalculator))) {}
+
+void ablate::monitors::MixtureFractionMonitor::Register(std::shared_ptr<solver::Solver> solverIn) {
+    // Name this monitor
+    auto monitorName = solverIn->GetSolverId() + "_mixtureFraction";
+
+    // Define the required fields
+    std::vector<std::shared_ptr<domain::FieldDescriptor>> fields{
+        std::make_shared<domain::FieldDescription>("zMix", "zMix", domain::FieldDescription::ONECOMPONENT, domain::FieldLocation::SOL, domain::FieldType::FVM),
+        std::make_shared<domain::FieldDescription>(ablate::finiteVolume::CompressibleFlowFields::YI_FIELD,
+                                                   ablate::finiteVolume::CompressibleFlowFields::YI_FIELD,
+                                                   mixtureFractionCalculator->GetEos()->GetSpecies(),
+                                                   domain::FieldLocation::SOL,
+                                                   domain::FieldType::FVM),
+        std::make_shared<domain::FieldDescription>("densityEnergySource", "energySource", domain::FieldDescription::ONECOMPONENT, domain::FieldLocation::SOL, domain::FieldType::FVM),
+        std::make_shared<domain::FieldDescription>("densityYiSource", "densityYiSource", mixtureFractionCalculator->GetEos()->GetSpecies(), domain::FieldLocation::SOL, domain::FieldType::FVM)};
+
+    // get the required function to compute density
+    densityFunction = mixtureFractionCalculator->GetEos()->GetThermodynamicFunction(eos::ThermodynamicProperty::Density, solverIn->GetSubDomain().GetFields());
+
+    // this probe will only work with fV flow with a single mpi rank for now.  It should be replaced with DMInterpolationEvaluate
+    auto finiteVolumeSolver = std::dynamic_pointer_cast<ablate::finiteVolume::FiniteVolumeSolver>(solverIn);
+    if (!finiteVolumeSolver) {
+        throw std::invalid_argument("The MixtureFractionMonitor monitor can only be used with ablate::finiteVolume::FiniteVolumeSolver");
+    }
+    // get a reference to the tchem reactions instance in the solver
+    tChemReactions = finiteVolumeSolver->FindProcess<ablate::finiteVolume::processes::TChemReactions>();
+
+    // call the base function to create the domain
+    FieldMonitor::Register(monitorName, solverIn, fields);
+}
+void ablate::monitors::MixtureFractionMonitor::Save(PetscViewer viewer, PetscInt sequenceNumber, PetscReal time) {
+    // get the required fields from the fieldDm and main dm
+    const auto& zMixMonitorField = monitorSubDomain->GetField("zMix");
+    const auto& yiMonitorField = monitorSubDomain->GetField(ablate::finiteVolume::CompressibleFlowFields::YI_FIELD);
+    const auto& energySourceField = monitorSubDomain->GetField("densityEnergySource");
+    const auto& densityYiSourceField = monitorSubDomain->GetField("densityYiSource");
+    const auto& eulerField = GetSolver()->GetSubDomain().GetField(ablate::finiteVolume::CompressibleFlowFields::EULER_FIELD);
+    const auto& densityYiField = GetSolver()->GetSubDomain().GetField(ablate::finiteVolume::CompressibleFlowFields::DENSITY_YI_FIELD);
+
+    // define a localFVec from the solution dm to compute the source terms
+    Vec sourceTermVec = nullptr;
+    if (tChemReactions) {
+        DMGetLocalVector(GetSolver()->GetSubDomain().GetDM(), &sourceTermVec) >> checkError;
+        VecZeroEntries(sourceTermVec);
+        auto fvSolver = std::dynamic_pointer_cast<ablate::finiteVolume::FiniteVolumeSolver>(GetSolver());
+        tChemReactions->AddChemistrySourceToFlow(*fvSolver, sourceTermVec);
+    }
+
+    // Get the arrays for the global vectors
+    const PetscScalar* solutionFieldArray;
+    PetscScalar* monitorFieldArray;
+    VecGetArrayRead(GetSolver()->GetSubDomain().GetSolutionVector(), &solutionFieldArray) >> checkError;
+    VecGetArray(monitorSubDomain->GetSolutionVector(), &monitorFieldArray) >> checkError;
+
+    // check for the tmpLocalFArray
+    const PetscScalar* sourceTermArray = nullptr;
+    if (sourceTermVec) {
+        VecGetArrayRead(sourceTermVec, &sourceTermArray) >> checkError;
+    }
+
+    // March over each cell in the monitorDm
+    PetscInt cStart, cEnd;
+    DMPlexGetHeightStratum(monitorSubDomain->GetDM(), 0, &cStart, &cEnd) >> checkError;
+
+    // Get the cells we need to march over
+    IS monitorToSolutionIs;
+    DMPlexGetSubpointIS(monitorSubDomain->GetDM(), &monitorToSolutionIs) >> checkError;
+    const PetscInt* monitorToSolution = nullptr;
+    ISGetIndices(monitorToSolutionIs, &monitorToSolution) >> checkError;
+
+    DMLabel solutionToMonitor;
+    DMPlexGetSubpointMap(monitorSubDomain->GetDM(), &solutionToMonitor) >> checkError;
+
+    // save time to get densityFunctionContext
+    const auto densityFunctionContext = densityFunction.context.get();
+
+    for (PetscInt monitorPt = cStart; monitorPt < cEnd; ++monitorPt) {
+        PetscInt solutionPt = monitorToSolution[monitorPt];
+
+        // Get the solutionField and monitorField
+        const PetscScalar* solutionField = nullptr;
+        DMPlexPointGlobalRead(GetSolver()->GetSubDomain().GetDM(), solutionPt, solutionFieldArray, &solutionField) >> checkError;
+        PetscScalar* monitorField = nullptr;
+        DMPlexPointGlobalRead(monitorSubDomain->GetDM(), monitorPt, monitorFieldArray, &monitorField) >> checkError;
+
+        const PetscScalar* sourceTermField = nullptr;
+        if (sourceTermArray) {
+            DMPlexPointGlobalRead(GetSolver()->GetSubDomain().GetDM(), solutionPt, sourceTermArray, &sourceTermField) >> checkError;
+        }
+        // Do not bother in ghost cells
+        if (solutionField && monitorField) {
+            // compute the density from the solutionPt
+            PetscReal density;
+            densityFunction.function(solutionField, &density, densityFunctionContext) >> checkError;
+
+            // Copy over and compute yi
+            for (PetscInt sp = 0; sp < yiMonitorField.numberComponents; sp++) {
+                monitorField[yiMonitorField.offset + sp] = solutionField[densityYiField.offset + sp] / density;
+            }
+
+            // Compute mixture fraction
+            monitorField[zMixMonitorField.offset] = mixtureFractionCalculator->Calculate(monitorField + yiMonitorField.offset);
+
+            if (sourceTermField) {
+                monitorField[energySourceField.offset] = sourceTermField[eulerField.offset + ablate::finiteVolume::CompressibleFlowFields::RHOE];
+                PetscArraycpy(monitorField + densityYiSourceField.offset, sourceTermField + densityYiField.offset, densityYiField.numberComponents);
+            }
+        }
+    }
+
+    // cleanup
+    if (sourceTermVec) {
+        VecRestoreArrayRead(sourceTermVec, &sourceTermArray) >> checkError;
+        DMRestoreLocalVector(GetSolver()->GetSubDomain().GetDM(), &sourceTermVec) >> checkError;
+    }
+    ISRestoreIndices(monitorToSolutionIs, &monitorToSolution) >> checkError;
+    VecRestoreArrayRead(GetSolver()->GetSubDomain().GetSolutionVector(), &solutionFieldArray) >> checkError;
+    VecRestoreArray(monitorSubDomain->GetSolutionVector(), &monitorFieldArray) >> checkError;
+
+    // Call the base Save function only after the subdomain global function is updated
+    FieldMonitor::Save(viewer, sequenceNumber, time);
+}
+
+#include "registrar.hpp"
+REGISTER(ablate::monitors::Monitor, ablate::monitors::MixtureFractionMonitor,
+         "This class computes the mixture fraction for each point in the domain and outputs zMix, Yi, and source terms to the hdf5 file",
+         ARG(ablate::chemistry::MixtureFractionCalculator, "mixtureFractionCalculator", "the calculator used to compute zMix"));

--- a/src/monitors/mixtureFractionMonitor.hpp
+++ b/src/monitors/mixtureFractionMonitor.hpp
@@ -1,0 +1,49 @@
+#ifndef ABLATELIBRARY_MIXTUREFRACTIONMONITOR_HPP
+#define ABLATELIBRARY_MIXTUREFRACTIONMONITOR_HPP
+
+#include <memory>
+#include "chemistry/mixtureFractionCalculator.hpp"
+#include "fieldMonitor.hpp"
+#include "finiteVolume/processes/tChemReactions.hpp"
+
+/**
+ * This class computes the mixture fraction for each point in the domain and outputs zMix, Yi, and source terms to the hdf5 file
+ */
+namespace ablate::monitors {
+
+class MixtureFractionMonitor : public FieldMonitor {
+   private:
+    //! the mixture fraction calculator
+    const std::shared_ptr<ablate::chemistry::MixtureFractionCalculator> mixtureFractionCalculator;
+
+    //! store a reference to a function to compute density from solution field
+    eos::ThermodynamicFunction densityFunction;
+
+    //! store an optional pointer to the TChemReactions to output chemistry source terms
+    std::shared_ptr<ablate::finiteVolume::processes::TChemReactions> tChemReactions;
+
+   public:
+    /**
+     * Create the mixture fraction monitor using a mixture fraction calculator
+     */
+    explicit MixtureFractionMonitor(std::shared_ptr<ablate::chemistry::MixtureFractionCalculator>);
+
+    /**
+     * Update the fields and save the results to an hdf5 file
+     * @param viewer
+     * @param sequenceNumber
+     * @param time
+     */
+    void Save(PetscViewer viewer, PetscInt sequenceNumber, PetscReal time) override;
+
+    /**
+     * this call setups the monitor and defines the mixture fraction fields
+     * method
+     * @param solverIn
+     */
+    void Register(std::shared_ptr<solver::Solver> solverIn) override;
+};
+
+}
+
+#endif  // ABLATELIBRARY_MIXTUREFRACTIONMONITOR_HPP

--- a/src/monitors/mixtureFractionMonitor.hpp
+++ b/src/monitors/mixtureFractionMonitor.hpp
@@ -44,6 +44,6 @@ class MixtureFractionMonitor : public FieldMonitor {
     void Register(std::shared_ptr<solver::Solver> solverIn) override;
 };
 
-}
+}  // namespace ablate::monitors
 
 #endif  // ABLATELIBRARY_MIXTUREFRACTIONMONITOR_HPP

--- a/src/monitors/monitor.hpp
+++ b/src/monitors/monitor.hpp
@@ -14,9 +14,22 @@ class Monitor {
 
    public:
     virtual ~Monitor() = default;
-    virtual void* GetContext() { return this; }
+    /**
+     * Override this function to setup the monitor
+     * @param solverIn
+     */
     virtual void Register(std::shared_ptr<solver::Solver> solverIn) { solver = solverIn; }
-    virtual PetscMonitorFunction GetPetscFunction() = 0;
+
+    /**
+     * Return a function to be called after every time step.  By default null is returned so this is never called
+     * @return
+     */
+    virtual PetscMonitorFunction GetPetscFunction() { return nullptr; }
+
+    /**
+     * return context to be returned to the PetscMonitorFunction.  By default this is a pointer to this instance
+     */
+    virtual void* GetContext() { return this; }
 
    protected:
     std::shared_ptr<solver::Solver> GetSolver() { return solver; }

--- a/src/parameters/parameters.hpp
+++ b/src/parameters/parameters.hpp
@@ -89,6 +89,21 @@ class Parameters {
         }
     }
 
+    /**
+     * tries to convert each item in this parameter to T and places in map
+     * @tparam T
+     * @param paramName
+     * @return
+     */
+    template <typename T>
+    std::map<std::string, T> ToMap() const {
+        std::map<std::string, T> map;
+        for (const auto& key : GetKeys()) {
+            map[key] = GetExpect<double>(key);
+        }
+        return map;
+    }
+
     void Fill(PetscOptions options) const;
 
     template <typename T>

--- a/src/solver/timeStepper.cpp
+++ b/src/solver/timeStepper.cpp
@@ -172,7 +172,9 @@ void ablate::solver::TimeStepper::Register(std::shared_ptr<ablate::solver::Solve
         monitors[solver->GetSolverId()].push_back(monitor);
 
         // register the monitor with the ts
-        TSMonitorSet(ts, monitor->GetPetscFunction(), monitor->GetContext(), NULL) >> checkError;
+        if (auto monitorFunction = monitor->GetPetscFunction()) {
+            TSMonitorSet(ts, monitorFunction, monitor->GetContext(), NULL) >> checkError;
+        }
     }
 
     // check to see if the solver implements a solver function

--- a/src/utilities/constants.hpp
+++ b/src/utilities/constants.hpp
@@ -6,10 +6,17 @@
 namespace ablate::utilities {
 class Constants {
    public:
-    /// Class Constants
-    inline static const PetscReal sbc = 5.6696e-8;  //!< Stefan-Boltzman Constant (J/K)
+    //! Stefan-Boltzman Constant (J/K)
+    inline static const PetscReal sbc = 5.6696e-8;
+
+    //! Pi
     inline static const PetscReal pi = 3.1415926535897932384626433832795028841971693993;
+
+    //! A very tiny number
     inline static const PetscReal tiny = 1e-30;
+
+    //! A somewhat small number
+    inline static const PetscReal small = 1e-10;
 };
 }  // namespace ablate::utilities
 

--- a/src/utilities/mathUtilities.hpp
+++ b/src/utilities/mathUtilities.hpp
@@ -30,6 +30,11 @@ class MathUtilities {
         return true;
     }
 
+    template <class R, class T>
+    static inline bool Equals(R test, T equal, T tolerance = 1.0E-8) {
+        return test > (equal - tolerance) && test < (equal + tolerance);
+    }
+
     template <class I, class T>
     static inline void NormVector(I dim, const T* in, T* out) {
         T mag = 0.0;

--- a/src/utilities/vectorUtilities.hpp
+++ b/src/utilities/vectorUtilities.hpp
@@ -44,6 +44,23 @@ class VectorUtilities {
         return result;
     }
 
+    /**
+     * Fills an array based upon a key vector and map
+     * @tparam T
+     * @param list
+     * @return
+     */
+    template <class K, class T>
+    static inline std::vector<T> Fill(const std::vector<K>& keys, const std::map<K, T>& values, T defaultValue = {}) {
+        std::vector<T> result(keys.size(), defaultValue);
+        for (std::size_t i = 0; i < keys.size(); i++) {
+            if (values.count(keys[i])) {
+                result[i] = values.at(keys[i]);
+            }
+        }
+        return result;
+    }
+
    private:
     /**
      * helper function for Concatenate to string

--- a/tests/unitTests/chemistry/CMakeLists.txt
+++ b/tests/unitTests/chemistry/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(unitTests
         PRIVATE
         chemTabModelTests.cpp
+        mixtureFractionCalculatorTests.cpp
         )

--- a/tests/unitTests/chemistry/mixtureFractionCalculatorTests.cpp
+++ b/tests/unitTests/chemistry/mixtureFractionCalculatorTests.cpp
@@ -1,0 +1,98 @@
+#include "PetscTestFixture.hpp"
+#include "chemistry/mixtureFractionCalculator.hpp"
+#include "eos/perfectGas.hpp"
+#include "eos/tChem.hpp"
+#include "gtest/gtest.h"
+#include "localPath.hpp"
+#include "parameters/mapParameters.hpp"
+
+struct MixtureFractionCalculatorParameters {
+    // inputs
+    std::function<std::shared_ptr<ablate::eos::TChem>()> createEOS;
+    std::map<std::string, double> massFractionsFuel;
+    std::map<std::string, double> massFractionsOxidizer;
+    std::vector<std::string> trackingElements;
+
+    // test parameters
+    std::vector<std::pair<std::map<std::string, double>, double>> parameters;
+};
+
+class MixtureFractionCalculatorFixture : public testing::TestWithParam<MixtureFractionCalculatorParameters> {};
+
+TEST_P(MixtureFractionCalculatorFixture, ShouldComputeMixtureFraction) {
+    // arrange
+    auto eos = GetParam().createEOS();
+    ablate::chemistry::MixtureFractionCalculator mixtureFractionCalculator(eos, GetParam().massFractionsFuel, GetParam().massFractionsOxidizer, GetParam().trackingElements);
+
+    // test each case
+    for (const auto& [inputMassFractions, expectedValue] : GetParam().parameters) {
+        // build a mixture fraction vector
+        std::vector<double> mixtureFraction(eos->GetSpecies().size());
+        for (const auto& [species, yi] : inputMassFractions) {
+            auto location = std::find(eos->GetSpecies().begin(), eos->GetSpecies().end(), species);
+            if (location != eos->GetSpecies().end()) {
+                auto i = std::distance(eos->GetSpecies().begin(), location);
+                mixtureFraction[i] = yi;
+            }
+        }
+        // act
+        auto zMix = mixtureFractionCalculator.Calculate(mixtureFraction.data());
+
+        // assert
+        ASSERT_NEAR(expectedValue, zMix, 1E-6);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(MixtureFractionCalculatorTests, MixtureFractionCalculatorFixture,
+                         testing::Values((MixtureFractionCalculatorParameters){.createEOS =
+                                                                                   []() { return std::make_shared<ablate::eos::TChem>("inputs/eos/grimech30.dat", "inputs/eos/thermo30.dat"); },
+                                                                               .massFractionsFuel = {{"CH4", 1.0}},
+                                                                               .massFractionsOxidizer = {{"O2", 1.0}},
+                                                                               .parameters =
+                                                                                   {
+                                                                                       {{{"CH4", 1}}, 1.0},
+                                                                                       {{{"O2", 1}}, 0.0},
+                                                                                       {{{"CH4", .25}, {"O2", 0.75}}, 0.25},
+                                                                                       {{{"CH4", .75}, {"O2", 0.25}}, 0.75},
+                                                                                       {{{"CH4", .5}, {"O2", .2}, {"H2O", .3}}, 0.5335695032217096},
+                                                                                       {{{"CH4", .1}, {"O2", .2}, {"H2O", .1}, {"AR", .6}}, 0.11118983440723654},
+                                                                                   }},
+                                         (MixtureFractionCalculatorParameters){.createEOS = []() { return std::make_shared<ablate::eos::TChem>("inputs/eos/gri30.yaml"); },
+                                                                               .massFractionsFuel = {{"CH4", 0.7}, {"CH", 0.3}},
+                                                                               .massFractionsOxidizer = {{"N2", 0.75511}, {"O2", 0.2314}, {"AR", 0.0129}, {"CO2", 0.00059}},
+                                                                               .parameters = {
+                                                                                   {{{"CH4", 0.7}, {"CH", 0.3}}, 1.0},
+                                                                                   {{{"N2", 0.75511}, {"O2", 0.2314}, {"AR", 0.0129}, {"CO2", 0.00059}}, 0},
+                                                                                   {{{"CH4", 0.23}, {"CH", 0.43}, {"AR", 0.0129}, {"CO2", 0.1}, {"O2", 0.1271}, {"N2", 0.2}}, 0.6872407932461698},
+                                                                               }}));
+
+struct MixtureFractionCalculatorExceptionParameters {
+    std::string name;
+    std::function<std::shared_ptr<ablate::eos::EOS>()> createEOS;
+    std::map<std::string, double> massFractionsFuel;
+    std::map<std::string, double> massFractionsOxidizer;
+    std::vector<std::string> trackingElements;
+};
+class MixtureFractionCalculatorExceptionFixture : public testingResources::PetscTestFixture, public ::testing::WithParamInterface<MixtureFractionCalculatorExceptionParameters> {};
+
+TEST_P(MixtureFractionCalculatorExceptionFixture, ShouldThrowExceptionWithInvalidInputs) {
+    // arrange
+    auto eos = GetParam().createEOS();
+    ASSERT_THROW(ablate::chemistry::MixtureFractionCalculator mixtureFractionCalculator(eos, GetParam().massFractionsFuel, GetParam().massFractionsOxidizer, GetParam().trackingElements);
+                 , std::invalid_argument);
+}
+
+INSTANTIATE_TEST_SUITE_P(MixtureFractionCalculatorTests, MixtureFractionCalculatorExceptionFixture,
+                         testing::Values((MixtureFractionCalculatorExceptionParameters){.name = "invalid EOS",
+                                                                                        .createEOS = []() { return std::make_shared<ablate::eos::PerfectGas>(ablate::parameters::MapParameters::Create({})); },
+                                                                                        .massFractionsFuel = {{"CH4", 1.0}},
+                                                                                        .massFractionsOxidizer = {{"O2", 1.0}}},
+                                         (MixtureFractionCalculatorExceptionParameters){.name = "invalid massFractionsFuel",
+                                                                                        .createEOS = []() { return std::make_shared<ablate::eos::TChem>("inputs/eos/gri30.yaml"); },
+                                                                                        .massFractionsFuel = {{"CH4", 0.7}},
+                                                                                        .massFractionsOxidizer = {{"N2", 0.75511}, {"O2", 0.2314}, {"AR", 0.0129}, {"CO2", 0.00059}}},
+                                         (MixtureFractionCalculatorExceptionParameters){.name = "invalid massFractionsOxidizer",
+                                                                                        .createEOS = []() { return std::make_shared<ablate::eos::TChem>("inputs/eos/gri30.yaml"); },
+                                                                                        .massFractionsFuel = {{"CH4", 1.0}},
+                                                                                        .massFractionsOxidizer = {{"N2", 0.75511}, {"O2", 0.2314}}}),
+                         [](const testing::TestParamInfo<MixtureFractionCalculatorExceptionParameters>& info) { return testingResources::PetscTestFixture::SanitizeTestName(info.param.name); });

--- a/tests/unitTests/eos/tChemTests.cpp
+++ b/tests/unitTests/eos/tChemTests.cpp
@@ -499,9 +499,9 @@ TEST_P(TChemFieldFunctionTestFixture, ShouldComputeField) {
 
     // act
     auto stateEulerFunction = eos->GetFieldFunctionFunction("euler", params.property1, params.property2);
-    stateEulerFunction(params.property1Value, params.property2Value, params.velocity.size(), params.velocity.data(), yi.data(), actualEulerValue.data());
+    stateEulerFunction(params.property1Value, params.property2Value, (PetscInt)params.velocity.size(), params.velocity.data(), yi.data(), actualEulerValue.data());
     auto stateDensityYiFunction = eos->GetFieldFunctionFunction("densityYi", params.property1, params.property2);
-    stateDensityYiFunction(params.property1Value, params.property2Value, params.velocity.size(), params.velocity.data(), yi.data(), actualDensityYiValue.data());
+    stateDensityYiFunction(params.property1Value, params.property2Value, (PetscInt)params.velocity.size(), params.velocity.data(), yi.data(), actualDensityYiValue.data());
 
     // assert
     for (std::size_t c = 0; c < params.expectedEulerValue.size(); c++) {
@@ -680,3 +680,156 @@ INSTANTIATE_TEST_SUITE_P(TChemTests, TChemFieldFunctionTestFixture,
                              return std::to_string(info.index) + "_from_" + std::string(to_string(info.param.property1)) + "_" + std::string(to_string(info.param.property2)) + "_with_" +
                                     info.param.mechFile.stem().string();
                          });
+
+struct TCElementTestParameters {
+    std::filesystem::path mechFile;
+    std::filesystem::path thermoFile;
+    std::map<std::string, double> expectedElementInformation;
+};
+
+class TCElementTestFixture : public testingResources::PetscTestFixture, public ::testing::WithParamInterface<TCElementTestParameters> {};
+
+TEST_P(TCElementTestFixture, ShouldDetermineElements) {
+    // arrange
+    auto eos = std::make_shared<ablate::eos::TChem>(GetParam().mechFile, GetParam().thermoFile);
+
+    // get the test params
+    const auto& params = GetParam();
+
+    // act
+    auto elementInformation = eos->GetElementInformation();
+
+    // assert
+    ASSERT_EQ(params.expectedElementInformation, elementInformation);
+}
+
+INSTANTIATE_TEST_SUITE_P(TChemTests, TCElementTestFixture,
+                         testing::Values(
+                             (TCElementTestParameters){
+                                 .mechFile = "inputs/eos/grimech30.dat",
+                                 .thermoFile = "inputs/eos/thermo30.dat",
+                                 .expectedElementInformation = {{"AR", 39.948}, {"C", 12.01115}, {"H", 1.00797}, {"N", 14.0067}, {"O", 15.9994}},
+                             },
+                             (TCElementTestParameters){.mechFile = "inputs/eos/gri30.yaml",
+                                                       .expectedElementInformation = {{"AR", 39.948}, {"C", 12.01115}, {"H", 1.00797}, {"N", 14.0067}, {"O", 15.9994}}}),
+                         [](const testing::TestParamInfo<TCElementTestParameters>& info) { return TCElementTestFixture::SanitizeTestName(info.param.mechFile.string()); });
+
+struct TCSpeciesInformationTestParameters {
+    std::filesystem::path mechFile;
+    std::filesystem::path thermoFile;
+    std::map<std::string, double> expectedSpeciesMolecularMass;
+    std::map<std::string, std::map<std::string, int>> expectedSpeciesElementInformation;
+};
+
+class TCSpeciesInformationTestFixture : public testingResources::PetscTestFixture, public ::testing::WithParamInterface<TCSpeciesInformationTestParameters> {};
+
+TEST_P(TCSpeciesInformationTestFixture, ShouldDetermineSpeciesElementInformation) {
+    // arrange
+    auto eos = std::make_shared<ablate::eos::TChem>(GetParam().mechFile, GetParam().thermoFile);
+
+    // get the test params
+    const auto& params = GetParam();
+
+    // act
+    auto speciesElementInformation = eos->GetSpeciesElementalInformation();
+
+    // assert
+    ASSERT_EQ(params.expectedSpeciesElementInformation, speciesElementInformation);
+}
+
+TEST_P(TCSpeciesInformationTestFixture, ShouldDetermineSpeciesMolecularMass) {
+    // arrange
+    auto eos = std::make_shared<ablate::eos::TChem>(GetParam().mechFile, GetParam().thermoFile);
+
+    // get the test params
+    const auto& params = GetParam();
+
+    // act
+    auto molecularMass = eos->GetSpeciesMolecularMass();
+
+    // assert
+    ASSERT_EQ(params.expectedSpeciesMolecularMass.size(), molecularMass.size()) << "the number of species should be correct";
+    for (const auto& [species, mw] : params.expectedSpeciesMolecularMass) {
+        EXPECT_NEAR(mw, molecularMass[species], 1E-2) << "the mw for " << species << " should be correct";
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TChemTests, TCSpeciesInformationTestFixture,
+    testing::Values(
+        (TCSpeciesInformationTestParameters){
+            .mechFile = "inputs/eos/grimech30.dat",
+            .thermoFile = "inputs/eos/thermo30.dat",
+            .expectedSpeciesMolecularMass = {{"AR", 39.948},     {"C", 12.0112},    {"C2H", 25.0303},   {"C2H2", 26.0382},  {"C2H3", 27.0462},   {"C2H4", 28.0542},   {"C2H5", 29.0622},
+                                             {"C2H6", 30.0701},  {"C3H7", 43.0892}, {"C3H8", 44.0972},  {"CH", 13.0191},    {"CH2", 14.0271},    {"CH2(S)", 14.0271}, {"CH2CHO", 43.0456},
+                                             {"CH2CO", 42.0376}, {"CH2O", 30.0265}, {"CH2OH", 31.0345}, {"CH3", 15.0351},   {"CH3CHO", 44.0536}, {"CH3O", 31.0345},   {"CH3OH", 32.0424},
+                                             {"CH4", 16.043},    {"CN", 26.0179},   {"CO", 28.0106},    {"CO2", 44.01},     {"H", 1.00797},      {"H2", 2.01594},     {"H2CN", 28.0338},
+                                             {"H2O", 18.0153},   {"H2O2", 34.0147}, {"HCCO", 41.0297},  {"HCCOH", 42.0376}, {"HCN", 27.0258},    {"HCNN", 41.0325},   {"HCNO", 43.0252},
+                                             {"HCO", 29.0185},   {"HNCO", 43.0252}, {"HNO", 31.0141},   {"HO2", 33.0068},   {"HOCN", 43.0252},   {"N", 14.0067},      {"N2", 28.0134},
+                                             {"N2O", 44.0128},   {"NCO", 42.0173},  {"NH", 15.0147},    {"NH2", 16.0226},   {"NH3", 17.0306},    {"NNH", 29.0214},    {"NO", 30.0061},
+                                             {"NO2", 46.0055},   {"O", 15.9994},    {"O2", 31.9988},    {"OH", 17.0074}},
+            .expectedSpeciesElementInformation = {{"AR", {{"AR", 1}, {"C", 0}, {"H", 0}, {"N", 0}, {"O", 0}}},     {"C", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 0}, {"O", 0}}},
+                                                  {"C2H", {{"AR", 0}, {"C", 2}, {"H", 1}, {"N", 0}, {"O", 0}}},    {"C2H2", {{"AR", 0}, {"C", 2}, {"H", 2}, {"N", 0}, {"O", 0}}},
+                                                  {"C2H3", {{"AR", 0}, {"C", 2}, {"H", 3}, {"N", 0}, {"O", 0}}},   {"C2H4", {{"AR", 0}, {"C", 2}, {"H", 4}, {"N", 0}, {"O", 0}}},
+                                                  {"C2H5", {{"AR", 0}, {"C", 2}, {"H", 5}, {"N", 0}, {"O", 0}}},   {"C2H6", {{"AR", 0}, {"C", 2}, {"H", 6}, {"N", 0}, {"O", 0}}},
+                                                  {"C3H7", {{"AR", 0}, {"C", 3}, {"H", 7}, {"N", 0}, {"O", 0}}},   {"C3H8", {{"AR", 0}, {"C", 3}, {"H", 8}, {"N", 0}, {"O", 0}}},
+                                                  {"CH", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 0}, {"O", 0}}},     {"CH2", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 0}, {"O", 0}}},
+                                                  {"CH2(S)", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 0}, {"O", 0}}}, {"CH2CHO", {{"AR", 0}, {"C", 2}, {"H", 3}, {"N", 0}, {"O", 1}}},
+                                                  {"CH2CO", {{"AR", 0}, {"C", 2}, {"H", 2}, {"N", 0}, {"O", 1}}},  {"CH2O", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 0}, {"O", 1}}},
+                                                  {"CH2OH", {{"AR", 0}, {"C", 1}, {"H", 3}, {"N", 0}, {"O", 1}}},  {"CH3", {{"AR", 0}, {"C", 1}, {"H", 3}, {"N", 0}, {"O", 0}}},
+                                                  {"CH3CHO", {{"AR", 0}, {"C", 2}, {"H", 4}, {"N", 0}, {"O", 1}}}, {"CH3O", {{"AR", 0}, {"C", 1}, {"H", 3}, {"N", 0}, {"O", 1}}},
+                                                  {"CH3OH", {{"AR", 0}, {"C", 1}, {"H", 4}, {"N", 0}, {"O", 1}}},  {"CH4", {{"AR", 0}, {"C", 1}, {"H", 4}, {"N", 0}, {"O", 0}}},
+                                                  {"CN", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 1}, {"O", 0}}},     {"CO", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 0}, {"O", 1}}},
+                                                  {"CO2", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 0}, {"O", 2}}},    {"H", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 0}, {"O", 0}}},
+                                                  {"H2", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 0}, {"O", 0}}},     {"H2CN", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 1}, {"O", 0}}},
+                                                  {"H2O", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 0}, {"O", 1}}},    {"H2O2", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 0}, {"O", 2}}},
+                                                  {"HCCO", {{"AR", 0}, {"C", 2}, {"H", 1}, {"N", 0}, {"O", 1}}},   {"HCCOH", {{"AR", 0}, {"C", 2}, {"H", 2}, {"N", 0}, {"O", 1}}},
+                                                  {"HCN", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 0}}},    {"HCNN", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 2}, {"O", 0}}},
+                                                  {"HCNO", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 1}}},   {"HCO", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 0}, {"O", 1}}},
+                                                  {"HNCO", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 1}}},   {"HNO", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 1}, {"O", 1}}},
+                                                  {"HO2", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 0}, {"O", 2}}},    {"HOCN", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 1}}},
+                                                  {"N", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 1}, {"O", 0}}},      {"N2", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 2}, {"O", 0}}},
+                                                  {"N2O", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 2}, {"O", 1}}},    {"NCO", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 1}, {"O", 1}}},
+                                                  {"NH", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 1}, {"O", 0}}},     {"NH2", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 1}, {"O", 0}}},
+                                                  {"NH3", {{"AR", 0}, {"C", 0}, {"H", 3}, {"N", 1}, {"O", 0}}},    {"NNH", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 2}, {"O", 0}}},
+                                                  {"NO", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 1}, {"O", 1}}},     {"NO2", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 1}, {"O", 2}}},
+                                                  {"O", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 0}, {"O", 1}}},      {"O2", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 0}, {"O", 2}}},
+                                                  {"OH", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 0}, {"O", 1}}}}},
+        (TCSpeciesInformationTestParameters){
+            .mechFile = "inputs/eos/gri30.yaml",
+            .expectedSpeciesMolecularMass = {{"AR", 39.948},     {"C", 12.0112},    {"C2H", 25.0303},   {"C2H2", 26.0382},  {"C2H3", 27.0462},   {"C2H4", 28.0542},   {"C2H5", 29.0622},
+                                             {"C2H6", 30.0701},  {"C3H7", 43.0892}, {"C3H8", 44.0972},  {"CH", 13.0191},    {"CH2", 14.0271},    {"CH2(S)", 14.0271}, {"CH2CHO", 43.0456},
+                                             {"CH2CO", 42.0376}, {"CH2O", 30.0265}, {"CH2OH", 31.0345}, {"CH3", 15.0351},   {"CH3CHO", 44.0536}, {"CH3O", 31.0345},   {"CH3OH", 32.0424},
+                                             {"CH4", 16.043},    {"CN", 26.0179},   {"CO", 28.0106},    {"CO2", 44.01},     {"H", 1.00797},      {"H2", 2.01594},     {"H2CN", 28.0338},
+                                             {"H2O", 18.0153},   {"H2O2", 34.0147}, {"HCCO", 41.0297},  {"HCCOH", 42.0376}, {"HCN", 27.0258},    {"HCNN", 41.0325},   {"HCNO", 43.0252},
+                                             {"HCO", 29.0185},   {"HNCO", 43.0252}, {"HNO", 31.0141},   {"HO2", 33.0068},   {"HOCN", 43.0252},   {"N", 14.0067},      {"N2", 28.0134},
+                                             {"N2O", 44.0128},   {"NCO", 42.0173},  {"NH", 15.0147},    {"NH2", 16.0226},   {"NH3", 17.0306},    {"NNH", 29.0214},    {"NO", 30.0061},
+                                             {"NO2", 46.0055},   {"O", 15.9994},    {"O2", 31.9988},    {"OH", 17.0074}},
+            .expectedSpeciesElementInformation = {{"AR", {{"AR", 1}, {"C", 0}, {"H", 0}, {"N", 0}, {"O", 0}}},     {"C", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 0}, {"O", 0}}},
+                                                  {"C2H", {{"AR", 0}, {"C", 2}, {"H", 1}, {"N", 0}, {"O", 0}}},    {"C2H2", {{"AR", 0}, {"C", 2}, {"H", 2}, {"N", 0}, {"O", 0}}},
+                                                  {"C2H3", {{"AR", 0}, {"C", 2}, {"H", 3}, {"N", 0}, {"O", 0}}},   {"C2H4", {{"AR", 0}, {"C", 2}, {"H", 4}, {"N", 0}, {"O", 0}}},
+                                                  {"C2H5", {{"AR", 0}, {"C", 2}, {"H", 5}, {"N", 0}, {"O", 0}}},   {"C2H6", {{"AR", 0}, {"C", 2}, {"H", 6}, {"N", 0}, {"O", 0}}},
+                                                  {"C3H7", {{"AR", 0}, {"C", 3}, {"H", 7}, {"N", 0}, {"O", 0}}},   {"C3H8", {{"AR", 0}, {"C", 3}, {"H", 8}, {"N", 0}, {"O", 0}}},
+                                                  {"CH", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 0}, {"O", 0}}},     {"CH2", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 0}, {"O", 0}}},
+                                                  {"CH2(S)", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 0}, {"O", 0}}}, {"CH2CHO", {{"AR", 0}, {"C", 2}, {"H", 3}, {"N", 0}, {"O", 1}}},
+                                                  {"CH2CO", {{"AR", 0}, {"C", 2}, {"H", 2}, {"N", 0}, {"O", 1}}},  {"CH2O", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 0}, {"O", 1}}},
+                                                  {"CH2OH", {{"AR", 0}, {"C", 1}, {"H", 3}, {"N", 0}, {"O", 1}}},  {"CH3", {{"AR", 0}, {"C", 1}, {"H", 3}, {"N", 0}, {"O", 0}}},
+                                                  {"CH3CHO", {{"AR", 0}, {"C", 2}, {"H", 4}, {"N", 0}, {"O", 1}}}, {"CH3O", {{"AR", 0}, {"C", 1}, {"H", 3}, {"N", 0}, {"O", 1}}},
+                                                  {"CH3OH", {{"AR", 0}, {"C", 1}, {"H", 4}, {"N", 0}, {"O", 1}}},  {"CH4", {{"AR", 0}, {"C", 1}, {"H", 4}, {"N", 0}, {"O", 0}}},
+                                                  {"CN", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 1}, {"O", 0}}},     {"CO", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 0}, {"O", 1}}},
+                                                  {"CO2", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 0}, {"O", 2}}},    {"H", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 0}, {"O", 0}}},
+                                                  {"H2", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 0}, {"O", 0}}},     {"H2CN", {{"AR", 0}, {"C", 1}, {"H", 2}, {"N", 1}, {"O", 0}}},
+                                                  {"H2O", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 0}, {"O", 1}}},    {"H2O2", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 0}, {"O", 2}}},
+                                                  {"HCCO", {{"AR", 0}, {"C", 2}, {"H", 1}, {"N", 0}, {"O", 1}}},   {"HCCOH", {{"AR", 0}, {"C", 2}, {"H", 2}, {"N", 0}, {"O", 1}}},
+                                                  {"HCN", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 0}}},    {"HCNN", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 2}, {"O", 0}}},
+                                                  {"HCNO", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 1}}},   {"HCO", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 0}, {"O", 1}}},
+                                                  {"HNCO", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 1}}},   {"HNO", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 1}, {"O", 1}}},
+                                                  {"HO2", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 0}, {"O", 2}}},    {"HOCN", {{"AR", 0}, {"C", 1}, {"H", 1}, {"N", 1}, {"O", 1}}},
+                                                  {"N", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 1}, {"O", 0}}},      {"N2", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 2}, {"O", 0}}},
+                                                  {"N2O", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 2}, {"O", 1}}},    {"NCO", {{"AR", 0}, {"C", 1}, {"H", 0}, {"N", 1}, {"O", 1}}},
+                                                  {"NH", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 1}, {"O", 0}}},     {"NH2", {{"AR", 0}, {"C", 0}, {"H", 2}, {"N", 1}, {"O", 0}}},
+                                                  {"NH3", {{"AR", 0}, {"C", 0}, {"H", 3}, {"N", 1}, {"O", 0}}},    {"NNH", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 2}, {"O", 0}}},
+                                                  {"NO", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 1}, {"O", 1}}},     {"NO2", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 1}, {"O", 2}}},
+                                                  {"O", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 0}, {"O", 1}}},      {"O2", {{"AR", 0}, {"C", 0}, {"H", 0}, {"N", 0}, {"O", 2}}},
+                                                  {"OH", {{"AR", 0}, {"C", 0}, {"H", 1}, {"N", 0}, {"O", 1}}}}}),
+    [](const testing::TestParamInfo<TCSpeciesInformationTestParameters>& info) { return TCElementTestFixture::SanitizeTestName(info.param.mechFile.string()); });

--- a/tests/unitTests/parameters/parameterTests.cpp
+++ b/tests/unitTests/parameters/parameterTests.cpp
@@ -651,4 +651,21 @@ INSTANTIATE_TEST_SUITE_P(ParameterTests, ParameterTestFixtureDoubleArray,
                                            std::make_tuple("", std::array<double, 4>{0, 0, 0, 0}), std::make_tuple("11.1 22.2 33.3 44.4", std::array<double, 4>{11.1, 22.2, 33.3, 44.4}),
                                            std::make_tuple("11.1 22.2 33.3 44.4 55.5", std::array<double, 4>{11.1, 22.2, 33.3, 44.4})));
 
+// map tests
+TEST(ParameterTests, ShouldConvertKeysToMap) {
+    // arrange
+    MockParameters mockParameters;
+    EXPECT_CALL(mockParameters, GetKeys()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::unordered_set<std::string>{"a", "b", "c"}));
+    EXPECT_CALL(mockParameters, GetString("a")).Times(::testing::Exactly(1)).WillOnce(::testing::Return("1"));
+    EXPECT_CALL(mockParameters, GetString("b")).Times(::testing::Exactly(1)).WillOnce(::testing::Return("2"));
+    EXPECT_CALL(mockParameters, GetString("c")).Times(::testing::Exactly(1)).WillOnce(::testing::Return("3"));
+
+    // act
+    auto actualValue = mockParameters.ToMap<int>();
+
+    // assert
+    std::map<std::string, int> expected{{"a", 1}, {"b", 2}, {"c", 3}};
+    EXPECT_EQ(actualValue, expected);
+}
+
 }  // namespace ablateTesting::parameters


### PR DESCRIPTION
This PR adds support for a chemistry monitor that outputs zMix, yi, and chemistry source terms.  It also introduces a base class that allows reuse of code for monitor hdf5 file output.  @jpdening I based this base class on some of your code so we could merge your monitor into use it.  The new monitor needs to be added with automated testing when the slab burner regression rate regression test is added.