### PR TITLE
improved error message for species init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.9.33)
+project(ablateLibrary VERSION 0.9.34)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/finiteVolume/fieldFunctions/massFractions.cpp
+++ b/src/finiteVolume/fieldFunctions/massFractions.cpp
@@ -1,6 +1,7 @@
 #include "massFractions.hpp"
 #include <algorithm>
 #include <mathFunctions/functionPointer.hpp>
+#include "utilities/vectorUtilities.hpp"
 
 ablate::finiteVolume::fieldFunctions::MassFractions::MassFractions(std::shared_ptr<ablate::eos::EOS> eos, std::vector<std::shared_ptr<mathFunctions::FieldFunction>> massFractionFieldFunctionsIn)
     : ablate::mathFunctions::FieldFunction("yi", std::make_shared<ablate::mathFunctions::FunctionPointer>(ablate::finiteVolume::fieldFunctions::MassFractions::ComputeYiFunction, this)),
@@ -17,7 +18,7 @@ ablate::finiteVolume::fieldFunctions::MassFractions::MassFractions(std::shared_p
         if (it != species.end()) {
             massFractionFunctions[std::distance(species.begin(), it)] = yiFunction->GetFieldFunction();
         } else {
-            throw std::invalid_argument("Cannot find field species " + yiFunction->GetName());
+            throw std::invalid_argument("Cannot find field species " + yiFunction->GetName() + ". Valid species names are: " + ablate::utilities::VectorUtilities::Concatenate(species));
         }
     }
 }

--- a/src/utilities/vectorUtilities.hpp
+++ b/src/utilities/vectorUtilities.hpp
@@ -1,5 +1,6 @@
 #ifndef ABLATELIBRARY_VECTORUTILITIES_HPP
 #define ABLATELIBRARY_VECTORUTILITIES_HPP
+#include <map>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -67,7 +68,17 @@ class VectorUtilities {
      * @param value
      * @return
      */
-    std::string toString(const std::string& value) { return value; }
+    static std::string toString(const std::string& value) { return value; }
+
+    /**
+     * helper function for Concatenate to string
+     * @param value
+     * @return
+     */
+    template <class T>
+    static std::string toString(const T& value) {
+        return std::to_string(value);
+    }
 
    public:
     /**
@@ -79,7 +90,7 @@ class VectorUtilities {
     template <class T>
     static inline std::string Concatenate(const std::vector<T>& vector, const std::string& delimiter = ", ") {
         using namespace std;
-        return std::accumulate(std::begin(vector), std::end(vector), std::string(), [&delimiter](std::string& ss, auto& s) { return ss.empty() ? to_string(s) : ss + delimiter + to_string(s); });
+        return std::accumulate(std::begin(vector), std::end(vector), std::string(), [&delimiter](std::string& ss, auto& s) { return ss.empty() ? toString(s) : ss + delimiter + toString(s); });
     }
 
     /**
@@ -90,15 +101,14 @@ class VectorUtilities {
      */
     template <class T, class S>
     static inline std::string Concatenate(const T* vector, S size, const std::string& delimiter = ", ") {
-        using namespace std;
         if (size <= 0) {
             return "";
         }
 
-        std::string result = to_string(vector[0]);
+        std::string result = toString(vector[0]);
 
         for (S i = 1; i < size; ++i) {
-            result += delimiter + to_string(vector[i]);
+            result += delimiter + toString(vector[i]);
         }
 
         return result;


### PR DESCRIPTION
this should close #349 

The error message will look something like:
`
terminating with uncaught exception of type std::invalid_argument: Cannot find field species PENTANE. Valid species names are: N2, NE, PENTANE(1), O2(2), H(3), HO2(4), O(5), OH(6), H2(7), H2O(8), H2O2(10), CO(11), CO2(12), CH2O(14), HCO(15), CH3(16), CH4(17), C2H4(20), CH3O(24), CH3OO(26), CH2CO(27), C2H5(28), C2H3(29), CH3OOH(33), C2H6(35), CH3CHO(36), C2H5O2(38), CH2CHO(39), CH3CO(56), C3H5O(78), C3H5O2(79), C3H5O3(80), C3H4O(82), C3H6O(84), NC3H7(100), IC3H7(101), C3H5(102), C3H6(103), S(104), S(106), S(123), C3H5O(137), C3H4O(138), C3H5O(139), C3H5O(175), C4H8(196), C4H7(198), C4H6(202), C4H8O(272), C5H11(425), C5H11(426), C5H11(427), C5H10(429), S(440), S(442), S(444), S(447), S(448), S(452), S(453), S(454), S(458), S(461), S(463), S(468), S(476), S(479), S(492), S(527), S(532), S(537), S(539), S(1005), S(1154), S(1253), S(1375), S(1471), S(1478), S(1639), S(1979), S(1993), S(2048), S(2579), S(2647), S(4085), C4H6(4465), S(4469), S(4470), C4H6(4580), S(4757), S(6326), S(6353), S(6354)
`