### PR TITLE
tchem update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.9.59)
+project(ablateLibrary VERSION 0.9.60)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)
@@ -38,7 +38,7 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif ()
 
 # Create the library for ablate
-add_library(ablateLibrary OBJECT)
+add_library(ablateLibrary SHARED)
 
 # Load in the subdirectories for the ablate library
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 endif ()
 
 # Create the library for ablate
-add_library(ablateLibrary SHARED)
+add_library(ablateLibrary OBJECT)
 
 # Load in the subdirectories for the ablate library
 add_subdirectory(src)

--- a/config/findTChem.cmake
+++ b/config/findTChem.cmake
@@ -12,7 +12,7 @@ elseif (NOT (DEFINED Tines_DIR|CACHE{Tines_DIR}|ENV{Tines_DIR}))
     set(TINES_SUNDIALS_WARNING OFF CACHE BOOL "" FORCE)
 
     FetchContent_Declare(tines
-            GIT_REPOSITORY https://github.com/UBCHREST/Tines.git
+            GIT_REPOSITORY https://github.com/sandialabs/Tines.git
             GIT_TAG main
             SOURCE_SUBDIR src
             )

--- a/src/eos/tChem.cpp
+++ b/src/eos/tChem.cpp
@@ -8,18 +8,19 @@
 #include "eos/tChem/speedOfSound.hpp"
 #include "eos/tChem/temperature.hpp"
 #include "finiteVolume/compressibleFlowFields.hpp"
+#include "monitors/logs/nullLog.hpp"
 #include "utilities/kokkosUtilities.hpp"
 #include "utilities/mpiUtilities.hpp"
 
-ablate::eos::TChem::TChem(std::filesystem::path mechanismFileIn, std::filesystem::path thermoFileIn) : EOS("TChem"), mechanismFile(std::move(mechanismFileIn)), thermoFile(std::move(thermoFileIn)) {
+ablate::eos::TChem::TChem(std::filesystem::path mechanismFileIn, std::filesystem::path thermoFileIn, std::shared_ptr<ablate::monitors::logs::Log> logIn)
+    : EOS("TChem"), mechanismFile(std::move(mechanismFileIn)), thermoFile(std::move(thermoFileIn)), log(logIn ? logIn : std::make_shared<ablate::monitors::logs::NullLog>()) {
     // setup/use Kokkos
     ablate::utilities::KokkosUtilities::Initialize();
 
     // create/parse the kinetic data
     if (thermoFile.empty()) {
         // Create a file to record the output
-
-        kineticsModel = tChemLib::KineticModelData(mechanismFile.string());
+        kineticsModel = tChemLib::KineticModelData(mechanismFile.string(), log->GetStream(), log->GetStream());
     } else {
         // TChem init reads/writes file it can only be done one at a time
         ablate::utilities::MpiUtilities::RoundRobin(PETSC_COMM_WORLD, [&](int rank) { kineticsModel = tChemLib::KineticModelData(mechanismFile.string(), thermoFile.string()); });
@@ -738,4 +739,5 @@ std::map<std::string, double> ablate::eos::TChem::GetSpeciesMolecularMass() cons
 
 #include "registrar.hpp"
 REGISTER(ablate::eos::EOS, ablate::eos::TChem, "[TChemV2](https://github.com/sandialabs/TChem) ideal gas eos", ARG(std::filesystem::path, "mechFile", "the mech file (CHEMKIN Format or Cantera Yaml)"),
-         OPT(std::filesystem::path, "thermoFile", "the thermo file (CHEMKIN Format if mech file is CHEMKIN)"));
+         OPT(std::filesystem::path, "thermoFile", "the thermo file (CHEMKIN Format if mech file is CHEMKIN)"),
+         OPT(ablate::monitors::logs::Log, "log", "An optional log for TChem echo output (only used with yaml input)"));

--- a/src/eos/tChem.hpp
+++ b/src/eos/tChem.hpp
@@ -11,6 +11,7 @@
 #include "eos/tChem/sensibleInternalEnergy.hpp"
 #include "eos/tChem/speedOfSound.hpp"
 #include "eos/tChem/temperature.hpp"
+#include "monitors/logs/log.hpp"
 #include "utilities/intErrorChecker.hpp"
 
 namespace ablate::eos {
@@ -24,6 +25,9 @@ class TChem : public EOS {
 
     //! the thermoFile may be empty when using yaml input file
     const std::filesystem::path thermoFile;
+
+    //! an optional log file for tchem echo redirection
+    std::shared_ptr<ablate::monitors::logs::Log> log;
 
     /**
      * The kinetic model data
@@ -51,7 +55,7 @@ class TChem : public EOS {
      * @param mechFile
      * @param optionalThermoFile
      */
-    explicit TChem(std::filesystem::path mechanismFile, std::filesystem::path thermoFile = {});
+    explicit TChem(std::filesystem::path mechanismFile, std::filesystem::path thermoFile = {}, std::shared_ptr<ablate::monitors::logs::Log> = {});
 
     /**
      * Single function to produce thermodynamic function for any property based upon the available fields

--- a/src/finiteVolume/processes/les.hpp
+++ b/src/finiteVolume/processes/les.hpp
@@ -12,7 +12,6 @@ class LES : public FlowProcess {
    public:
     /* store turbulent diffusion  data */
     struct DiffusionData {
-        NavierStokesTransport* computeTau;
         PetscInt numberSpecies;
         PetscInt numberEV;
         PetscInt tke_ev;
@@ -28,7 +27,7 @@ class LES : public FlowProcess {
     inline const static PetscReal scT = 1.00;
     inline const static PetscReal prT = 1.00;
 
-    DiffusionData diffusionData;
+    DiffusionData diffusionData{};
 
    public:
     explicit LES(std::string tke);

--- a/src/monitors/logs/CMakeLists.txt
+++ b/src/monitors/logs/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(ablateLibrary
         streamLog.cpp
         fileLog.cpp
         stdOut.cpp
+        mpiFileLog.cpp
 
         PUBLIC
         log.hpp
@@ -13,4 +14,5 @@ target_sources(ablateLibrary
         fileLog.hpp
         stdOut.hpp
         nullLog.hpp
+        mpiFileLog.hpp
         )

--- a/src/monitors/logs/CMakeLists.txt
+++ b/src/monitors/logs/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources(ablateLibrary
         streamLog.hpp
         fileLog.hpp
         stdOut.hpp
+        nullLog.hpp
         )

--- a/src/monitors/logs/log.cpp
+++ b/src/monitors/logs/log.cpp
@@ -1,5 +1,11 @@
 #include "log.hpp"
 
+ablate::monitors::logs::Log::~Log() {
+    if (ostream) {
+        ostream->flush();
+    }
+}
+
 void ablate::monitors::logs::Log::Print(const char* name, std::size_t num, const double* values, const char* formatIn) {
     // print the name
     Printf("%s: ", name);
@@ -25,3 +31,11 @@ void ablate::monitors::logs::Log::Print(const char* name, std::size_t num, const
 }
 
 void ablate::monitors::logs::Log::Print(const char* name, const std::vector<double>& values, const char* format) { Print(name, values.size(), &values[0], format); }
+
+std::ostream& ablate::monitors::logs::Log::GetStream() {
+    if (!ostream) {
+        ostreambuf = std::make_unique<DefaultOutBuffer>(*this);
+        ostream = std::make_unique<std::ostream>(ostreambuf.get());
+    }
+    return *ostream;
+}

--- a/src/monitors/logs/log.hpp
+++ b/src/monitors/logs/log.hpp
@@ -2,6 +2,8 @@
 #define ABLATELIBRARY_LOG_HPP
 
 #include <petsc.h>
+#include <memory>
+#include <ostream>
 #include <vector>
 
 namespace ablate::monitors::logs {
@@ -9,8 +11,33 @@ class Log {
    private:
     bool initialized = false;
 
+    /**
+     * Private class to wrap the default Log in to a stream buf
+     */
+    class DefaultOutBuffer : public std::streambuf {
+       private:
+        Log& log;
+
+       protected:
+        int_type overflow(int_type c) override {
+            if (c != EOF) {
+                log.Printf("%c", static_cast<char>(c));
+            }
+            return c;
+        }
+
+       public:
+        DefaultOutBuffer(Log& log) : log(log) {}
+    };
+
+    // store pointer for an ostream
+    std::unique_ptr<std::ostream> ostream;
+
+    // store the pointer for a stream buffer
+    std::unique_ptr<DefaultOutBuffer> ostreambuf;
+
    public:
-    virtual ~Log() = default;
+    virtual ~Log();
 
     // each log must support the print command
     virtual void Printf(const char*, ...) = 0;
@@ -23,6 +50,12 @@ class Log {
 
     // determine if the log has been initialized
     inline const bool& Initialized() const { return initialized; }
+
+    /**
+     * Return access to an underlying stream.  Default implementation creates a stream that calls print
+     * @return
+     */
+    virtual std::ostream& GetStream();
 };
 }  // namespace ablate::monitors::logs
 

--- a/src/monitors/logs/mpiFileLog.cpp
+++ b/src/monitors/logs/mpiFileLog.cpp
@@ -1,0 +1,38 @@
+#include "mpiFileLog.hpp"
+#include <utilities/mpiError.hpp>
+#include <utilities/petscError.hpp>
+#include "environment/runEnvironment.hpp"
+
+ablate::monitors::logs::MpiFileLog::MpiFileLog(std::string fileName)
+    : outputPath(std::filesystem::path(fileName).is_absolute() ? std::filesystem::path(fileName) : ablate::environment::RunEnvironment::Get().GetOutputDirectory() / fileName), file(nullptr) {}
+
+ablate::monitors::logs::MpiFileLog::~MpiFileLog() {
+    if (file) {
+        fflush(file);
+        fclose(file);
+    }
+}
+
+void ablate::monitors::logs::MpiFileLog::Initialize(MPI_Comm commIn) {
+    Log::Initialize(commIn);
+
+    // Update the output path with the rank
+    int rank;
+    MPI_Comm_rank(commIn, &rank) >> checkMpiError;
+    outputPath = outputPath.parent_path() / (outputPath.stem().string() + "." + std::to_string(rank) + outputPath.extension().string());
+    file = fopen(outputPath.c_str(), "a");
+    std::cout << outputPath << std::endl;
+}
+
+void ablate::monitors::logs::MpiFileLog::Printf(const char* format, ...) {
+    if (file) {
+        va_list args;
+        va_start(args, format);
+        PetscVFPrintf(file, format, args) >> checkError;
+        va_end(args);
+    }
+}
+
+#include "registrar.hpp"
+REGISTER(ablate::monitors::logs::Log, ablate::monitors::logs::MpiFileLog, "Writes the log of each rank to a separate file such that (file.txt => file.0.txt).  ",
+         ARG(std::string, "name", "the base name of the log file"));

--- a/src/monitors/logs/mpiFileLog.hpp
+++ b/src/monitors/logs/mpiFileLog.hpp
@@ -1,0 +1,24 @@
+#ifndef ABLATELIBRARY_MPIFILELOG_HPP
+#define ABLATELIBRARY_MPIFILELOG_HPP
+
+#include <petsc.h>
+#include <filesystem>
+#include "log.hpp"
+
+namespace ablate::monitors::logs {
+
+class MpiFileLog : public Log {
+   private:
+    std::filesystem::path outputPath;
+    FILE *file = nullptr;
+
+   public:
+    explicit MpiFileLog(std::string fileName);
+    ~MpiFileLog() override;
+
+    void Printf(const char *, ...) final;
+    void Initialize(MPI_Comm comm) final;
+};
+}  // namespace ablate::monitors::logs
+
+#endif  // ABLATELIBRARY_MPIFILELOG_HPP

--- a/src/monitors/logs/nullLog.hpp
+++ b/src/monitors/logs/nullLog.hpp
@@ -1,0 +1,41 @@
+#ifndef ABLATELIBRARY_NULLLOG_HPP
+#define ABLATELIBRARY_NULLLOG_HPP
+
+#include <iostream>
+#include <ostream>
+#include <vector>
+#include "log.hpp"
+
+namespace ablate::monitors::logs {
+class NullLog : public Log {
+   private:
+    /**
+     * Simple null buffer
+     */
+    class NullBuffer : public std::streambuf {
+       protected:
+        int_type overflow(int_type c) override { return c; }
+    };
+
+    inline static NullBuffer nullBuffer;
+
+   public:
+    /**
+     * public static null stream that can be used by others
+     */
+    inline static std::ostream nullStream = std::ostream(&nullBuffer);
+
+   public:
+    void Print(const char*) override {}
+    void Printf(const char*, ...) override {}
+    void Initialize(MPI_Comm comm) override {}
+
+    /**
+     * Return access a null stream
+     * @return
+     */
+    std::ostream& GetStream() override { return nullStream; }
+};
+}  // namespace ablate::monitors::logs
+
+#endif  // ABLATELIBRARY_NULLLOG_HPP

--- a/src/monitors/logs/stdOut.cpp
+++ b/src/monitors/logs/stdOut.cpp
@@ -2,6 +2,7 @@
 #include <stdarg.h>
 #include <utilities/mpiError.hpp>
 #include <utilities/petscError.hpp>
+#include "nullLog.hpp"
 
 void ablate::monitors::logs::StdOut::Initialize(MPI_Comm comm) {
     Log::Initialize(comm);
@@ -16,6 +17,13 @@ void ablate::monitors::logs::StdOut::Printf(const char* format, ...) {
         va_start(args, format);
         PetscVFPrintf(PETSC_STDOUT, format, args) >> checkError;
         va_end(args);
+    }
+}
+std::ostream& ablate::monitors::logs::StdOut::GetStream() {
+    if (output) {
+        return std::cout;
+    } else {
+        return NullLog::nullStream;
     }
 }
 

--- a/src/monitors/logs/stdOut.hpp
+++ b/src/monitors/logs/stdOut.hpp
@@ -1,5 +1,6 @@
 #ifndef ABLATELIBRARY_STDOUT_HPP
 #define ABLATELIBRARY_STDOUT_HPP
+#include <iostream>
 #include "log.hpp"
 
 namespace ablate::monitors::logs {
@@ -11,6 +12,12 @@ class StdOut : public Log {
     void Printf(const char*, ...) final;
 
     void Initialize(MPI_Comm comm) final;
+
+    /**
+     * Return access to an underlying stream
+     * @return
+     */
+    std::ostream& GetStream() override;
 };
 }  // namespace ablate::monitors::logs
 

--- a/src/monitors/logs/streamLog.hpp
+++ b/src/monitors/logs/streamLog.hpp
@@ -18,6 +18,12 @@ class StreamLog : public Log {
     void Printf(const char*, ...) override;
 
     void Initialize(MPI_Comm comm) override;
+
+    /**
+     * Return access to an underlying stream
+     * @return
+     */
+    std::ostream& GetStream() override { return stream; }
 };
 }  // namespace ablate::monitors::logs
 

--- a/tests/unitTests/finiteVolume/processes/lesSourceTests.cpp
+++ b/tests/unitTests/finiteVolume/processes/lesSourceTests.cpp
@@ -20,9 +20,7 @@ class lesEvSourceTestFixture : public testingResources::PetscTestFixture, public
 TEST_P(lesEvSourceTestFixture, ShouldComputeCorrectFlux) {
     // arrange
     const auto &params = GetParam();
-    ablate::finiteVolume::processes::LES::DiffusionData flowParam;
-    flowParam.numberEV = params.numberEv;
-    flowParam.tke_ev = params.tke_ev;
+    ablate::finiteVolume::processes::LES::DiffusionData flowParam{.numberEV = params.numberEv, .tke_ev = params.tke_ev};
 
     PetscFVFaceGeom faceGeom{};
     std::copy(std::begin(params.area), std::end(params.area), faceGeom.normal);
@@ -34,7 +32,8 @@ TEST_P(lesEvSourceTestFixture, ShouldComputeCorrectFlux) {
     std::vector<PetscReal> computedFlux(params.expectedFlux.size());
 
     // act
-    ablate::finiteVolume::processes::LES::LesEvFlux(params.area.size(), &faceGeom, uOff, NULL, &params.field[0], NULL, aOff, aOff_x, &params.EVs[0], &params.Grad[0], &computedFlux[0], &flowParam);
+    ablate::finiteVolume::processes::LES::LesEvFlux(
+        (PetscInt)params.area.size(), &faceGeom, uOff, nullptr, params.field.data(), nullptr, aOff, aOff_x, params.EVs.data(), params.Grad.data(), computedFlux.data(), &flowParam);
 
     // assert
     for (std::size_t i = 0; i < params.expectedFlux.size(); i++) {
@@ -44,12 +43,12 @@ TEST_P(lesEvSourceTestFixture, ShouldComputeCorrectFlux) {
 
 INSTANTIATE_TEST_SUITE_P(
     lesTransportTests, lesEvSourceTestFixture,
-    testing::Values((lesEvSourceTestParameters){.area = {0.5}, .field = {1.130}, .tke_ev = {1}, .numberEv = {2}, .EVs = {1.1, 0.93}, .Grad = {1.19, 1.43, 0.014}, .expectedFlux = {-0.0517, 0.494}},
+    testing::Values((lesEvSourceTestParameters){.area = {0.5}, .field = {1.130}, .tke_ev = 1, .numberEv = 2, .EVs = {1.1, 0.93}, .Grad = {1.19, 1.43, 0.014}, .expectedFlux = {-0.0517, 0.494}},
 
-                    (lesEvSourceTestParameters){.area = {0.5}, .field = {1.130}, .tke_ev = {0}, .numberEv = {2}, .EVs = {0.93, 1.1}, .Grad = {1.19, 0.014, 1.43}, .expectedFlux = {0.494, -0.0517}},
+                    (lesEvSourceTestParameters){.area = {0.5}, .field = {1.130}, .tke_ev = 0, .numberEv = 2, .EVs = {0.93, 1.1}, .Grad = {1.19, 0.014, 1.43}, .expectedFlux = {0.494, -0.0517}},
 
                     (lesEvSourceTestParameters){
-                        .area = {1.5}, .field = {1.130}, .tke_ev = {2}, .numberEv = {3}, .EVs = {0.93, 1.1, 0.43}, .Grad = {1.19, 0.56, 2.14, 0.12}, .expectedFlux = {-0.072, -0.273, 0.261}}
+                        .area = {1.5}, .field = {1.130}, .tke_ev = 2, .numberEv = 3, .EVs = {0.93, 1.1, 0.43}, .Grad = {1.19, 0.56, 2.14, 0.12}, .expectedFlux = {-0.072, -0.273, 0.261}}
 
                     ));
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -69,7 +68,7 @@ class lesSpeciesSourceTestFixture : public testingResources::PetscTestFixture, p
 TEST_P(lesSpeciesSourceTestFixture, ShouldComputeCorrectFlux) {
     // arrange
     const auto &params = GetParam();
-    ablate::finiteVolume::processes::LES::DiffusionData flowParam;
+    ablate::finiteVolume::processes::LES::DiffusionData flowParam{};
     flowParam.tke_ev = params.tke_ev;
     flowParam.numberSpecies = params.numberSpecies;
 
@@ -84,7 +83,7 @@ TEST_P(lesSpeciesSourceTestFixture, ShouldComputeCorrectFlux) {
 
     // act
     ablate::finiteVolume::processes::LES::LesSpeciesFlux(
-        params.area.size(), &faceGeom, uOff, NULL, &params.field[0], NULL, aOff, aOff_x, &params.EVs[0], &params.Grad[0], &computedFlux[0], &flowParam);
+        (PetscInt)params.area.size(), &faceGeom, uOff, nullptr, &params.field[0], nullptr, aOff, aOff_x, &params.EVs[0], &params.Grad[0], &computedFlux[0], &flowParam);
 
     // assert
     for (std::size_t i = 0; i < params.expectedFlux.size(); i++) {
@@ -95,26 +94,26 @@ TEST_P(lesSpeciesSourceTestFixture, ShouldComputeCorrectFlux) {
 INSTANTIATE_TEST_SUITE_P(lesTransportTests, lesSpeciesSourceTestFixture,
                          testing::Values((lesSpeciesSourceTestParameters){.area = {1.5},
                                                                           .field = {1.130},
-                                                                          .tke_ev = {1},
+                                                                          .tke_ev = 1,
                                                                           .EVs = {0.93, 1.10},
-                                                                          .numberSpecies = {2},
+                                                                          .numberSpecies = 2,
 
                                                                           .Grad = {0.52, 0.3},
                                                                           .expectedFlux = {-0.106, -.0613}},
                                          (lesSpeciesSourceTestParameters){.area = {1.5},
                                                                           .field = {1.130},
-                                                                          .tke_ev = {0},
+                                                                          .tke_ev = 0,
                                                                           .EVs = {0.93, 1.10},
-                                                                          .numberSpecies = {2},
+                                                                          .numberSpecies = 2,
 
                                                                           .Grad = {0.52, 0.3},
                                                                           .expectedFlux = {-0.097, -.057}},
 
                                          (lesSpeciesSourceTestParameters){.area = {0.5},
                                                                           .field = {1.130},
-                                                                          .tke_ev = {0},
+                                                                          .tke_ev = 0,
                                                                           .EVs = {0.93, 1.10},
-                                                                          .numberSpecies = {3},
+                                                                          .numberSpecies = 3,
 
                                                                           .Grad = {0.52, 0.3, 0.97},
                                                                           .expectedFlux = {-0.018, -0.0108, -0.035}}

--- a/tests/unitTests/monitors/logs/fileLogTests.cpp
+++ b/tests/unitTests/monitors/logs/fileLogTests.cpp
@@ -33,6 +33,10 @@ TEST_P(FileLogTestFixture, ShouldPrintToFile) {
 
             log.Print("Log Out Log\n");
             log.Printf("rank: %d\n", rank);
+
+            // Should also print from a stream
+            auto& stream = log.GetStream();
+            stream << "stream: " << rank << std::endl;
         }
         ablate::environment::RunEnvironment::Finalize();
         exit(0);
@@ -43,7 +47,7 @@ TEST_P(FileLogTestFixture, ShouldPrintToFile) {
     std::stringstream buffer;
     buffer << logFile.rdbuf();
 
-    ASSERT_EQ(buffer.str(), "Log Out Log\nrank: 0\n");
+    ASSERT_EQ(buffer.str(), "Log Out Log\nrank: 0\nstream: 0\n");
 }
 
 TEST_P(FileLogTestFixture, ShouldPrintToFileInOutputDirectory) {
@@ -133,4 +137,4 @@ TEST_P(FileLogTestFixture, ShouldAppendToFileInOutputDirectory) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LogTests, FileLogTestFixture, testing::Values((MpiTestParameter){.testName = "logFile 1 proc", .nproc = 1, .arguments = ""}),
-                         [](const testing::TestParamInfo<MpiTestParameter> &info) { return info.param.getTestName(); });
+                         [](const testing::TestParamInfo<MpiTestParameter>& info) { return info.param.getTestName(); });

--- a/tests/unitTests/monitors/logs/stdOutTests.cpp
+++ b/tests/unitTests/monitors/logs/stdOutTests.cpp
@@ -30,6 +30,10 @@ TEST_P(StdOutLogTestFixture, ShouldPrintToStdOut) {
 
             log.Print("Standard Out Log\n");
             log.Printf("rank: %d\n", rank);
+
+            // Should also print from a stream
+            auto& stream = log.GetStream();
+            stream << "stream: " << rank << std::endl;
         }
         ablate::environment::RunEnvironment::Finalize();
         exit(0);
@@ -39,4 +43,4 @@ TEST_P(StdOutLogTestFixture, ShouldPrintToStdOut) {
 INSTANTIATE_TEST_SUITE_P(LogTests, StdOutLogTestFixture,
                          testing::Values((MpiTestParameter){.testName = "std out 1 proc", .nproc = 1, .expectedOutputFile = "outputs/monitors/logs/stdOutLogFile", .arguments = ""},
                                          (MpiTestParameter){.testName = "std out 2 proc", .nproc = 2, .expectedOutputFile = "outputs/monitors/logs/stdOutLogFile", .arguments = ""}),
-                         [](const testing::TestParamInfo<MpiTestParameter> &info) { return info.param.getTestName(); });
+                         [](const testing::TestParamInfo<MpiTestParameter>& info) { return info.param.getTestName(); });

--- a/tests/unitTests/monitors/logs/streamLogTests.cpp
+++ b/tests/unitTests/monitors/logs/streamLogTests.cpp
@@ -16,8 +16,12 @@ TEST(StreamLog, ShouldPrintToStream) {
         log.Print("StreamLog\n");
         log.Printf("Line %d\n", 12);
         log.Printf("Line %d, Line %d\n", 14, 16);
+
+        // Should also print from a stream
+        auto& stream = log.GetStream();
+        stream << "Stream " << 23 << std::endl;
     }
 
     // assert
-    ASSERT_EQ("StreamLog\nLine 12\nLine 14, Line 16\n", outputStream.str());
+    ASSERT_EQ("StreamLog\nLine 12\nLine 14, Line 16\nStream 23\n", outputStream.str());
 }

--- a/tests/unitTests/outputs/monitors/logs/stdOutLogFile
+++ b/tests/unitTests/outputs/monitors/logs/stdOutLogFile
@@ -1,2 +1,3 @@
 Standard Out Log
 rank: 0
+stream: 0


### PR DESCRIPTION
This PR switches to the Sandia repo for Tines and updates TChem to the latest CHREST version which allows for stream based echo when using Yaml input files.  This removes the need to round robin the initialization for tchem. As part of this new logs were added and the ability to get a stream from the log is now supported.  @Rozie100 this PR also cleans up some compiler warnings in the LES tests.  @jpdening would you mind building with this and running a case on quartz to see if there are any issues with large initialization? 