### PR TITLE
Use Swarm Location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.9.61)
+project(ablateLibrary VERSION 0.9.62)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/eos/radiationProperties/sootMeanAbsorption.cpp
+++ b/src/eos/radiationProperties/sootMeanAbsorption.cpp
@@ -11,7 +11,7 @@ PetscErrorCode ablate::eos::radiationProperties::SootMeanAbsorption::SootFunctio
 
     ierr = functionContext->temperatureFunction.function(conserved, &temperature, functionContext->temperatureFunction.context.get());  //!< Get the temperature value at this location
     CHKERRQ(ierr);
-    ierr = functionContext->densityFunction.function(conserved, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
+    ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
     CHKERRQ(ierr);
 
     PetscReal YinC = (functionContext->densityEVCOffset == -1) ? 0 : conserved[functionContext->densityEVCOffset] / density;  //!< Get the mass fraction of carbon here
@@ -30,7 +30,7 @@ PetscErrorCode ablate::eos::radiationProperties::SootMeanAbsorption::SootTempera
     double density;       //!< Variables to hold information gathered from the fields
     PetscErrorCode ierr;  //!< Standard PETSc error code returned by PETSc functions
 
-    ierr = functionContext->densityFunction.function(conserved, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
+    ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
     CHKERRQ(ierr);
 
     PetscReal YinC = (functionContext->densityEVCOffset == -1) ? 0 : conserved[functionContext->densityEVCOffset] / density;  //!< Get the mass fraction of carbon here
@@ -66,7 +66,7 @@ ablate::eos::ThermodynamicFunction ablate::eos::radiationProperties::SootMeanAbs
                                          .context = std::make_shared<FunctionContext>(
                                              FunctionContext{.densityEVCOffset = Coffset,
                                                              .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
-                                                             .densityFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+                                                             .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::SootAbsorptionModel");
     }
@@ -97,7 +97,7 @@ ablate::eos::ThermodynamicTemperatureFunction ablate::eos::radiationProperties::
                                                     .context = std::make_shared<FunctionContext>(FunctionContext{
                                                         .densityEVCOffset = Coffset,
                                                         .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
-                                                        .densityFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+                                                        .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::SootAbsorptionModel");
     }

--- a/src/eos/radiationProperties/sootMeanAbsorption.cpp
+++ b/src/eos/radiationProperties/sootMeanAbsorption.cpp
@@ -63,10 +63,10 @@ ablate::eos::ThermodynamicFunction ablate::eos::radiationProperties::SootMeanAbs
     switch (property) {
         case RadiationProperty::Absorptivity:
             return ThermodynamicFunction{.function = SootFunction,
-                                         .context = std::make_shared<FunctionContext>(
-                                             FunctionContext{.densityEVCOffset = Coffset,
-                                                             .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
-                                                             .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+                                         .context = std::make_shared<FunctionContext>(FunctionContext{
+                                             .densityEVCOffset = Coffset,
+                                             .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
+                                             .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::SootAbsorptionModel");
     }
@@ -93,11 +93,12 @@ ablate::eos::ThermodynamicTemperatureFunction ablate::eos::radiationProperties::
 
     switch (property) {
         case RadiationProperty::Absorptivity:
-            return ThermodynamicTemperatureFunction{.function = SootTemperatureFunction,
-                                                    .context = std::make_shared<FunctionContext>(FunctionContext{
-                                                        .densityEVCOffset = Coffset,
-                                                        .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
-                                                        .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+            return ThermodynamicTemperatureFunction{
+                .function = SootTemperatureFunction,
+                .context = std::make_shared<FunctionContext>(
+                    FunctionContext{.densityEVCOffset = Coffset,
+                                    .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
+                                    .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::SootAbsorptionModel");
     }

--- a/src/eos/radiationProperties/sootMeanAbsorption.hpp
+++ b/src/eos/radiationProperties/sootMeanAbsorption.hpp
@@ -12,7 +12,7 @@ class SootMeanAbsorption : public RadiationModel {
     struct FunctionContext {
         PetscInt densityEVCOffset;
         const ThermodynamicFunction temperatureFunction;
-        const ThermodynamicFunction densityFunction;
+        const ThermodynamicTemperatureFunction densityFunction;
     };
     const std::shared_ptr<eos::EOS> eos;  //! eos is needed to compute field values
     constexpr static PetscReal C_2 = (utilities::Constants::h * utilities::Constants::c) / (utilities::Constants::k);

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -13,7 +13,7 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const Pe
 
     ierr = functionContext->temperatureFunction.function(conserved, &temperature, functionContext->temperatureFunction.context.get());  //!< Get the temperature value at this location
     CHKERRQ(ierr);
-    ierr = functionContext->densityFunction.function(conserved, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
+    ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
     CHKERRQ(ierr);
 
     if (density == 0) {
@@ -73,7 +73,7 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerTemperatureFuncti
     double density;       //!< Variables to hold information gathered from the fields
     PetscErrorCode ierr;  //!< Standard PETSc error code returned by PETSc functions
 
-    ierr = functionContext->densityFunction.function(conserved, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
+    ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
     CHKERRQ(ierr);
 
     if (density == 0) {
@@ -156,7 +156,7 @@ ablate::eos::ThermodynamicFunction ablate::eos::radiationProperties::Zimmer::Get
                                                              .densityYiCOOffset = COoffset,
                                                              .densityYiCH4Offset = CH4offset,
                                                              .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
-                                                             .densityFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+                                                             .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::Zimmer");
     }
@@ -193,7 +193,7 @@ ablate::eos::ThermodynamicTemperatureFunction ablate::eos::radiationProperties::
                                                         .densityYiCOOffset = COoffset,
                                                         .densityYiCH4Offset = CH4offset,
                                                         .temperatureFunction = {},
-                                                        .densityFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+                                                        .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::Zimmer");
     }

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -8,13 +8,16 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const Pe
 
     /** This model depends on mass fraction, temperature, and density in order to predict the absorption properties of the medium. */
     auto functionContext = (FunctionContext *)ctx;
-    double temperature, density;  //!< Variables to hold information gathered from the fields
-    PetscErrorCode ierr;          //!< Standard PETSc error code returned by PETSc functions
+    PetscReal temperature = 0;
+    PetscReal density = 0;  //!< Variables to hold information gathered from the fields
+    PetscErrorCode ierr;    //!< Standard PETSc error code returned by PETSc functions
 
     ierr = functionContext->temperatureFunction.function(conserved, &temperature, functionContext->temperatureFunction.context.get());  //!< Get the temperature value at this location
     CHKERRQ(ierr);
-    ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
-    CHKERRQ(ierr);
+    if (temperature != 0) {
+        ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
+        CHKERRQ(ierr);
+    }
 
     if (density == 0) {
         *kappa = 0;
@@ -70,11 +73,13 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerTemperatureFuncti
 
     /** This model depends on mass fraction, temperature, and density in order to predict the absorption properties of the medium. */
     auto functionContext = (FunctionContext *)ctx;
-    double density;       //!< Variables to hold information gathered from the fields
-    PetscErrorCode ierr;  //!< Standard PETSc error code returned by PETSc functions
+    PetscReal density = 0;  //!< Variables to hold information gathered from the fields
+    PetscErrorCode ierr;    //!< Standard PETSc error code returned by PETSc functions
 
-    ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
-    CHKERRQ(ierr);
+    if (temperature != 0) {
+        ierr = functionContext->densityFunction.function(conserved, temperature, &density, functionContext->densityFunction.context.get());  //!< Get the density value at this location
+        CHKERRQ(ierr);
+    }
 
     if (density == 0) {
         *kappa = 0;
@@ -150,13 +155,13 @@ ablate::eos::ThermodynamicFunction ablate::eos::radiationProperties::Zimmer::Get
     switch (property) {
         case RadiationProperty::Absorptivity:
             return ThermodynamicFunction{.function = ZimmerFunction,
-                                         .context = std::make_shared<FunctionContext>(
-                                             FunctionContext{.densityYiH2OOffset = H2Ooffset,
-                                                             .densityYiCO2Offset = CO2offset,
-                                                             .densityYiCOOffset = COoffset,
-                                                             .densityYiCH4Offset = CH4offset,
-                                                             .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
-                                                             .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+                                         .context = std::make_shared<FunctionContext>(FunctionContext{
+                                             .densityYiH2OOffset = H2Ooffset,
+                                             .densityYiCO2Offset = CO2offset,
+                                             .densityYiCOOffset = COoffset,
+                                             .densityYiCH4Offset = CH4offset,
+                                             .temperatureFunction = eos->GetThermodynamicFunction(ThermodynamicProperty::Temperature, fields),
+                                             .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::Zimmer");
     }
@@ -186,14 +191,15 @@ ablate::eos::ThermodynamicTemperatureFunction ablate::eos::radiationProperties::
 
     switch (property) {
         case RadiationProperty::Absorptivity:
-            return ThermodynamicTemperatureFunction{.function = ZimmerTemperatureFunction,
-                                                    .context = std::make_shared<FunctionContext>(FunctionContext{
-                                                        .densityYiH2OOffset = H2Ooffset,
-                                                        .densityYiCO2Offset = CO2offset,
-                                                        .densityYiCOOffset = COoffset,
-                                                        .densityYiCH4Offset = CH4offset,
-                                                        .temperatureFunction = {},
-                                                        .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
+            return ThermodynamicTemperatureFunction{
+                .function = ZimmerTemperatureFunction,
+                .context = std::make_shared<FunctionContext>(
+                    FunctionContext{.densityYiH2OOffset = H2Ooffset,
+                                    .densityYiCO2Offset = CO2offset,
+                                    .densityYiCOOffset = COoffset,
+                                    .densityYiCH4Offset = CH4offset,
+                                    .temperatureFunction = {},
+                                    .densityFunction = eos->GetThermodynamicTemperatureFunction(ThermodynamicProperty::Density, fields)})};  //!< Create a struct to hold the offsets
         default:
             throw std::invalid_argument("Unknown radiationProperties property in ablate::eos::radiationProperties::Zimmer");
     }

--- a/src/eos/radiationProperties/zimmer.hpp
+++ b/src/eos/radiationProperties/zimmer.hpp
@@ -18,7 +18,7 @@ class Zimmer : public RadiationModel {
         PetscInt densityYiCOOffset;
         PetscInt densityYiCH4Offset;
         const ThermodynamicFunction temperatureFunction;
-        const ThermodynamicFunction densityFunction;
+        const ThermodynamicTemperatureFunction densityFunction;
     };
 
     /**

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -18,8 +18,8 @@ ablate::radiation::Radiation::Radiation(const std::string& solverId, const std::
 
 ablate::radiation::Radiation::~Radiation() {
     if (radsolve) DMDestroy(&radsolve) >> checkError;  //!< Destroy the radiation particle swarm
-    VecDestroy(&faceGeomVec) >> checkError;
-    VecDestroy(&cellGeomVec) >> checkError;
+    if (faceGeomVec) VecDestroy(&faceGeomVec) >> checkError;
+    if (cellGeomVec) VecDestroy(&cellGeomVec) >> checkError;
 }
 
 /** allows initialization after the subdomain and dm is established */

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -94,7 +94,7 @@ void ablate::radiation::Radiation::Setup(const solver::Range& cellRange, ablate:
     DMSwarmSetLocalSizes(radsolve, 0, 0) >> checkError;         //!< Set the number of initial particles to the number of rays in the subdomain. Set the buffer size to zero.
 
     /** Declare some information associated with the field declarations */
-    PetscReal* coord;                   //!< Pointer to the coordinate field information
+    PetscReal* coord;  //!< Pointer to the coordinate field information
     PetscInt* index;
     struct Virtualcoord* virtualcoord;  //!< Pointer to the primary (virtual) coordinate field information
     struct Identifier* identifier;      //!< Pointer to the ray identifier information
@@ -169,7 +169,7 @@ void ablate::radiation::Radiation::Initialize(const solver::Range& cellRange, ab
     VecGetArrayRead(faceGeomVec, &faceGeomArray) >> checkError;
 
     /** Declare some information associated with the field declarations */
-    PetscReal* coord;                   //!< Pointer to the coordinate field information
+    PetscReal* coord;  //!< Pointer to the coordinate field information
     PetscInt* index;
     struct Virtualcoord* virtualcoord;  //!< Pointer to the primary (virtual) coordinate field information
     struct Identifier* identifier;      //!< Pointer to the ray identifier information

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -534,7 +534,7 @@ void ablate::radiation::Radiation::Solve(Vec solVec, ablate::domain::Field tempe
         if (log) {
             PetscReal centroid[3];
             DMPlexComputeCellGeometryFVM(solDm, index, nullptr, centroid, nullptr) >> checkError;  //!< Reads the cell location from the current cell
-            log->Printf("%f %f %f %f %f %f\n", centroid[0], centroid[1], centroid[2], origin[iCell].intensity, losses, *temperature);
+            printf("%f %f %f %f %f %f\n", centroid[0], centroid[1], centroid[2], origin[iCell].intensity, losses, *temperature);
         }
         origin[iCell].intensity = -kappa * (losses - origin[iCell].intensity);
     }

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -95,7 +95,7 @@ void ablate::radiation::Radiation::Setup(const solver::Range& cellRange, ablate:
 
     /** Declare some information associated with the field declarations */
     PetscReal* coord;  //!< Pointer to the coordinate field information
-    PetscInt* index;
+    PetscInt* index;   //!< Pointer to the cell index information
     struct Virtualcoord* virtualcoord;  //!< Pointer to the primary (virtual) coordinate field information
     struct Identifier* identifier;      //!< Pointer to the ray identifier information
 
@@ -193,7 +193,7 @@ void ablate::radiation::Radiation::Initialize(const solver::Range& cellRange, ab
         /** Get all of the ray information from the particle
          * Get the ntheta and nphi from the particle that is currently being looked at. This will be used to identify its ray and calculate its direction. */
         DMSwarmGetField(radsearch, DMSwarmPICField_coor, nullptr, nullptr, (void**)&coord) >> checkError;
-        DMSwarmGetField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&coord) >> checkError;
+        DMSwarmGetField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
         DMSwarmGetField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
         DMSwarmGetField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
 

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -592,7 +592,6 @@ void ablate::radiation::Radiation::ParticleStep(ablate::domain::SubDomain& subDo
     PetscInt npoints = 0;
     PetscInt nglobalpoints = 0;
     PetscInt nsolvepoints = 0;  //!< Counts the solve points in the current domain. This will be adjusted over the course of the loop.
-    PetscInt ipart = -1;
 
     DMSwarmGetLocalSize(radsearch, &npoints) >> checkError;
     DMSwarmGetSize(radsearch, &nglobalpoints) >> checkError;
@@ -616,10 +615,8 @@ void ablate::radiation::Radiation::ParticleStep(ablate::domain::SubDomain& subDo
     DMSwarmGetField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
     DMSwarmGetField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
 
-    for (PetscInt ip = 0; ip < npoints; ip++) {
-        ipart++;  //!< USE IP TO DEAL WITH DMLOCATE POINTS, USE IPART TO DEAL WITH PARTICLES
-                  /** Check that the particle is in a valid region */
-
+    for (PetscInt ipart = 0; ipart < npoints; ipart++) {
+        /** Check that the particle is in a valid region */
         //!< Compare against the field with the DMLocatePoints output instead of the output itself. This might be a little memory inefficient.
         if (index[ipart] >= 0 && subDomain.InRegion(index[ipart])) {
             /** If this local rank has never seen this search particle before, then it needs to add a new ray segment to local memory

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -94,8 +94,8 @@ void ablate::radiation::Radiation::Setup(const solver::Range& cellRange, ablate:
     DMSwarmSetLocalSizes(radsolve, 0, 0) >> checkError;         //!< Set the number of initial particles to the number of rays in the subdomain. Set the buffer size to zero.
 
     /** Declare some information associated with the field declarations */
-    PetscReal* coord;  //!< Pointer to the coordinate field information
-    PetscInt* index;   //!< Pointer to the cell index information
+    PetscReal* coord;                   //!< Pointer to the coordinate field information
+    PetscInt* index;                    //!< Pointer to the cell index information
     struct Virtualcoord* virtualcoord;  //!< Pointer to the primary (virtual) coordinate field information
     struct Identifier* identifier;      //!< Pointer to the ray identifier information
 
@@ -132,7 +132,7 @@ void ablate::radiation::Radiation::Setup(const solver::Range& cellRange, ablate:
                 virtualcoord[ipart].z = centroid[2] + (virtualcoord[ipart].zdir * 0.1 * minCellRadius);
 
                 /** Update the physical coordinate field so that the real particle location can be updated. */
-                UpdateCoordinates(ipart, virtualcoord, coord, 0.0); //! adv value of 0.0 places the particle exactly where the virtual coordinates are.
+                UpdateCoordinates(ipart, virtualcoord, coord, 0.0);  //! adv value of 0.0 places the particle exactly where the virtual coordinates are.
 
                 /** Label the particle with the ray identifier. (Use an array of 4 ints, [ncell][theta][phi][domains crossed])
                  * Label the particle with nsegment = 0; so that this can be iterated after each domain cross.
@@ -243,8 +243,8 @@ void ablate::radiation::Radiation::Initialize(const solver::Range& cellRange, ab
                  * It doesn't matter which method is used,
                  * this will be the same procedure.
                  * */
-                UpdateCoordinates(ipart, virtualcoord, coord, 0.1); //!< Update the coordinates of the particle to move it to the center of the adjacent particle.
-                virtualcoord[ipart].hhere = 0;  //!< Reset the path length to zero
+                UpdateCoordinates(ipart, virtualcoord, coord, 0.1);  //!< Update the coordinates of the particle to move it to the center of the adjacent particle.
+                virtualcoord[ipart].hhere = 0;                       //!< Reset the path length to zero
             }
         }
         /** Restore the fields associated with the particles after all of the particles have been stepped */
@@ -398,7 +398,7 @@ void ablate::radiation::Radiation::Solve(Vec solVec, ablate::domain::Field tempe
 
     /** ********************************************************************************************************************************
      * Now iterate through all of the particles in order to perform the information transfer */
-    DMSwarmGetLocalSize(radsolve, &npoints);                                         //!< Recalculate the number of particles that are in the domain
+    DMSwarmGetLocalSize(radsolve, &npoints);                                                       //!< Recalculate the number of particles that are in the domain
     DMSwarmGetField(radsolve, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;  //!< Field information is needed in order to read data from the incoming particles.
     DMSwarmGetField(radsolve, "carrier", nullptr, nullptr, (void**)&carrier) >> checkError;
 
@@ -498,7 +498,7 @@ void ablate::radiation::Radiation::Solve(Vec solVec, ablate::domain::Field tempe
 
             DMSwarmRemovePointAtIndex(radsolve, ipart);  //!< Delete the particle!
 
-            DMSwarmGetLocalSize(radsolve, &npoints);                                         //!< Need to recalculate the number of particles that are in the domain again
+            DMSwarmGetLocalSize(radsolve, &npoints);                                                       //!< Need to recalculate the number of particles that are in the domain again
             DMSwarmGetField(radsolve, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;  //!< Get the field back
             DMSwarmGetField(radsolve, "carrier", nullptr, nullptr, (void**)&carrier) >> checkError;
             ipart--;  //!< Check the point replacing the one that was deleted

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -155,6 +155,8 @@ void ablate::radiation::Radiation::Setup(const solver::Range& cellRange, ablate:
     DMSwarmRestoreField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
     DMSwarmRestoreField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
 
+    DMSwarmMigrate(radsearch, PETSC_TRUE) >> checkError;  //!< Sets the search particles in the cell indexes to which they have been assigned
+
     if (log) {
         log->Printf("Particles Setup\n");
     }

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -111,7 +111,6 @@ class Radiation : public utilities::Loggable<Radiation> {  //!< Cell solver prov
         PetscReal ydir;
         PetscReal zdir;
         PetscReal hhere;
-        PetscReal ihere;
     };
 
     /// Class Methods

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -124,8 +124,13 @@ class Radiation : public utilities::Loggable<Radiation> {  //!< Cell solver prov
 
     /** Update the coordinates of the particle using the virtual coordinates
      * Moves the particle in physical space instead of only updating the virtual coordinates
-     * This function must be run on every updated particle before swarm migrate is used */
-    void UpdateCoordinates(PetscInt ipart, Virtualcoord* virtualcoord, PetscReal* coord) const;
+     * This function must be run on every updated particle before swarm migrate is used
+     * @param ipart the particle index which is being updated
+     * @param virtualcoord the virtual coordinate field which is being read from
+     * @param coord the DMSwarm coordinate field which is being written to
+     * @param adv a multiple of the minimum cell radius by which to advance the DMSwarm coordinates ahead of the virtual coordinates
+     * */
+    void UpdateCoordinates(PetscInt ipart, Virtualcoord* virtualcoord, PetscReal* coord, PetscReal adv) const;
 
     /** Create a unique identifier from an array of integers.
      * This is done using the nested Cantor pairing function

--- a/src/radiation/raySharingRadiation.cpp
+++ b/src/radiation/raySharingRadiation.cpp
@@ -60,7 +60,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
                 solveidentifier[newpoint] = identifier[ipart];  //!< Give the particle an identifier which matches the particle it was created with
                 /** Create a new 'access identifier' and set it equal to the identifier of the current cell which the search particle is occupying */
                 access[newpoint].origin = rank;                      //!< The origin should be the current rank
-                access[newpoint].iCell = index[ipart];                      //!< The index that the particle is currently occupying
+                access[newpoint].iCell = index[ipart];               //!< The index that the particle is currently occupying
                 access[newpoint].ntheta = identifier[ipart].ntheta;  //!< The angle of the ray we want
                 access[newpoint].nphi = identifier[ipart].nphi;      //!< The angle of the ray we want
                 access[newpoint].nsegment = 1;                       //!< The access identifier should always point to a native rank (segment == 1)

--- a/src/radiation/raySharingRadiation.cpp
+++ b/src/radiation/raySharingRadiation.cpp
@@ -23,7 +23,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
 
     PetscFVFaceGeom* faceGeom;
 
-    PetscInt index;
+    PetscInt* index;
     PetscMPIInt rank = 0;
     MPI_Comm_rank(subDomain.GetComm(), &rank);
 
@@ -40,9 +40,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
     DMSwarmGetField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
 
     for (PetscInt ipart = 0; ipart < npoints; ipart++) {
-        if (virtualcoord[ipart].ihere >= 0 && subDomain.InRegion(virtualcoord[ipart].ihere)) {
-            index = virtualcoord[ipart].ihere;
-
+        if (index[ipart] >= 0 && subDomain.InRegion(index[ipart])) {
             /** If this local rank has never seen this search particle before, then it needs to add a new ray segment to local memory
              * Hash the identifier into a key value that can be used in the map
              * We should only iterate the identifier of the search particle (/ add a solver particle) if the point is valid in the domain and is being used
@@ -62,7 +60,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
                 solveidentifier[newpoint] = identifier[ipart];  //!< Give the particle an identifier which matches the particle it was created with
                 /** Create a new 'access identifier' and set it equal to the identifier of the current cell which the search particle is occupying */
                 access[newpoint].origin = rank;                      //!< The origin should be the current rank
-                access[newpoint].iCell = index;                      //!< The index that the particle is currently occupying
+                access[newpoint].iCell = index[ipart];                      //!< The index that the particle is currently occupying
                 access[newpoint].ntheta = identifier[ipart].ntheta;  //!< The angle of the ray we want
                 access[newpoint].nphi = identifier[ipart].nphi;      //!< The angle of the ray we want
                 access[newpoint].nsegment = 1;                       //!< The access identifier should always point to a native rank (segment == 1)
@@ -104,7 +102,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
 
             /** Step 1: Register the current cell index in the rays vector. The physical coordinates that have been set in the previous step / loop will be immediately registered.
              * */
-            if (identifier[ipart].nsegment == 1) rays[Key(&identifier[ipart])].cells.push_back(index);
+            if (identifier[ipart].nsegment == 1) rays[Key(&identifier[ipart])].cells.push_back(index[ipart]);
 
             /** Step 2: Acquire the intersection of the particle search line with the segment or face. In the case if a two dimensional mesh, the virtual coordinate in the z direction will
              * need to be solved for because the three dimensional line will not have a literal intersection with the segment of the cell. The third coordinate can be solved for in this case.
@@ -113,8 +111,8 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
             /** March over each face on this cell in order to check them for the one which intersects this ray next */
             PetscInt numberFaces;
             const PetscInt* cellFaces;
-            DMPlexGetConeSize(subDomain.GetDM(), index, &numberFaces) >> checkError;
-            DMPlexGetCone(subDomain.GetDM(), index, &cellFaces) >> checkError;  //!< Get the face geometry associated with the current cell
+            DMPlexGetConeSize(subDomain.GetDM(), index[ipart], &numberFaces) >> checkError;
+            DMPlexGetCone(subDomain.GetDM(), index[ipart], &cellFaces) >> checkError;  //!< Get the face geometry associated with the current cell
             PetscReal path;
 
             /** Check every face for intersection with the segment.

--- a/src/radiation/raySharingRadiation.cpp
+++ b/src/radiation/raySharingRadiation.cpp
@@ -43,7 +43,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
     for (PetscInt ipart = 0; ipart < npoints; ipart++) {
         if (index[ipart] >= 0 && subDomain.InRegion(index[ipart])) {
             /** If this local rank has never seen this search particle before, then it needs to add a new ray segment to local memory
-             * Hash the identifier into a key value that can be used in the map
+             * Hash the identifier into a key value that can be used in the ma
              * We should only iterate the identifier of the search particle (/ add a solver particle) if the point is valid in the domain and is being used
              * */
             if (presence.count(Key(&identifier[ipart])) == 0) {  //!< IF THIS RAYS VECTOR IS EMPTY FOR THIS DOMAIN, THEN THE PARTICLE HAS NEVER BEEN HERE BEFORE. THEREFORE, ITERATE THE NDOMAINS BY 1.

--- a/src/radiation/raySharingRadiation.cpp
+++ b/src/radiation/raySharingRadiation.cpp
@@ -38,6 +38,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
      * Get the ntheta and nphi from the particle that is currently being looked at. This will be used to identify its ray and calculate its direction. */
     DMSwarmGetField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
     DMSwarmGetField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
+    DMSwarmGetField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
 
     for (PetscInt ipart = 0; ipart < npoints; ipart++) {
         if (index[ipart] >= 0 && subDomain.InRegion(index[ipart])) {
@@ -146,6 +147,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
     }
     DMSwarmRestoreField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
     DMSwarmRestoreField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
+    DMSwarmRestoreField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
 }
 
 #include "registrar.hpp"

--- a/src/radiation/surfaceRadiation.cpp
+++ b/src/radiation/surfaceRadiation.cpp
@@ -14,12 +14,14 @@ ablate::radiation::SurfaceRadiation::~SurfaceRadiation() {
 }
 
 void ablate::radiation::SurfaceRadiation::Initialize(const solver::Range& cellRange, ablate::domain::SubDomain& subDomain) { /** Declare some information associated with the field declarations */
-    PetscReal* coord;                                                                                                        //!< Pointer to the coordinate field information
+    PetscReal* coord;
+    PetscInt* index;//!< Pointer to the coordinate field information
     struct Virtualcoord* virtualcoord;                                                                                       //!< Pointer to the primary (virtual) coordinate field information
     struct Identifier* identifier;                                                                                           //!< Pointer to the ray identifier information
 
     /** Get the fields associated with the particle swarm so that they can be modified */
     DMSwarmGetField(radsearch, DMSwarmPICField_coor, nullptr, nullptr, (void**)&coord) >> checkError;
+    DMSwarmGetField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
     DMSwarmGetField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
     DMSwarmGetField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
 
@@ -28,55 +30,12 @@ void ablate::radiation::SurfaceRadiation::Initialize(const solver::Range& cellRa
     PetscMPIInt rank = 0;
     MPI_Comm_rank(subDomain.GetComm(), &rank);
 
-    /** Iterate over the particles that are present in the domain
-     * Add the cell index to the ray
-     * Step every particle in the domain one step and then perform a migration
-     * */
-    Vec intersect;
-    VecCreate(PETSC_COMM_SELF, &intersect) >> checkError;  //!< Instantiates the vector
-    VecSetBlockSize(intersect, dim) >> checkError;
-    VecSetSizes(intersect, PETSC_DECIDE, npoints * dim) >> checkError;  //!< Set size
-    VecSetFromOptions(intersect) >> checkError;
-    PetscInt i[3] = {0, 1, 2};                   //!< Establish the vector here so that it can be iterated.
-    for (PetscInt ip = 0; ip < npoints; ip++) {  //!< Iterate over the particles present in the domain.
-        /** Get the particle coordinates here and put them into the intersect */
-        PetscReal position[3] = {(coord[dim * ip + 0]),   //!< x component conversion from spherical coordinates, adding the position of the current cell
-                                 (coord[dim * ip + 1]),   //!< y component conversion from spherical coordinates, adding the position of the current cell
-                                 (coord[dim * ip + 2])};  //!< z component conversion from spherical coordinates, adding the position of the current cell
-
-        /** This block creates the vector pointing to the cell whose index will be stored during the current loop */
-        VecSetValues(intersect, dim, i, position, INSERT_VALUES);  //!< Actually input the values of the vector (There are 'dim' values to input)
-        i[0] += dim;                                               //!< Iterate the index by the number of dimensions so that the DMLocatePoints function can be called collectively.
-        i[1] += dim;
-        i[2] += dim;
-    }
-
-    /** Loop through points to try to get the cell that is sitting on that point */
-    PetscSF cellSF = nullptr;  //!< PETSc object for setting up and managing the communication of certain entries of arrays and Vecs between MPI processes.
-    DMLocatePoints(subDomain.GetDM(), intersect, DM_POINTLOCATION_NONE, &cellSF) >> checkError;  //!< Call DMLocatePoints here, all of the processes have to call it at once.
-
-    /** An array that maps each point to its containing cell can be obtained with the below
-     * We want to get a PetscInt index out of the DMLocatePoints function (cell[n].index)
-     * */
-    PetscInt nFound;
-    const PetscInt* point = nullptr;
-    const PetscSFNode* cell = nullptr;
-    PetscSFGetGraph(cellSF, nullptr, &nFound, &point, &cell) >> checkError;  //!< Using this to get the petsc int cell number from the struct (SF)
-
-    //!< Iterate through the output of DMLocate points and put it into a field associated with the search particles.
-    for (PetscInt ipart = 0; ipart < nFound; ipart++) {
-        virtualcoord[ipart].ihere = cell[ipart].index;  //!< Write the DMLocatePoints output to a field value so the information is not affected by rearrangement.
-    }
-
-    /** Cleanup */
-    VecDestroy(&intersect) >> checkError;   //!< Return the vector to PETSc
-    PetscSFDestroy(&cellSF) >> checkError;  //!< Return the stuff to PETSc
-
     /**  */
     for (PetscInt ipart = 0; ipart < npoints; ipart++) {
         //!< If the particles that were just created are sitting in the boundary cell of the face that they belong to, delete them
-        if (!(region->InRegion(region, subDomain.GetDM(), virtualcoord[ipart].ihere))) {  //!< If the particle location index and boundary cell index are the same, then they should be deleted
+        if (!(region->InRegion(region, subDomain.GetDM(), index[ipart]))) {  //!< If the particle location index and boundary cell index are the same, then they should be deleted
             DMSwarmRestoreField(radsearch, DMSwarmPICField_coor, nullptr, nullptr, (void**)&coord) >> checkError;
+            DMSwarmRestoreField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
             DMSwarmRestoreField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
             DMSwarmRestoreField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
 
@@ -84,6 +43,7 @@ void ablate::radiation::SurfaceRadiation::Initialize(const solver::Range& cellRa
             DMSwarmGetLocalSize(radsearch, &npoints);
 
             DMSwarmGetField(radsearch, DMSwarmPICField_coor, nullptr, nullptr, (void**)&coord) >> checkError;
+            DMSwarmGetField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
             DMSwarmGetField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
             DMSwarmGetField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
             ipart--;  //!< Check the point replacing the one that was deleted
@@ -92,6 +52,7 @@ void ablate::radiation::SurfaceRadiation::Initialize(const solver::Range& cellRa
 
     /** Restore the fields associated with the particles */
     DMSwarmRestoreField(radsearch, DMSwarmPICField_coor, nullptr, nullptr, (void**)&coord) >> checkError;
+    DMSwarmRestoreField(radsearch, DMSwarmPICField_cellid, nullptr, nullptr, (void**)&index) >> checkError;
     DMSwarmRestoreField(radsearch, "identifier", nullptr, nullptr, (void**)&identifier) >> checkError;
     DMSwarmRestoreField(radsearch, "virtual coord", nullptr, nullptr, (void**)&virtualcoord) >> checkError;
 

--- a/src/radiation/surfaceRadiation.cpp
+++ b/src/radiation/surfaceRadiation.cpp
@@ -15,9 +15,9 @@ ablate::radiation::SurfaceRadiation::~SurfaceRadiation() {
 
 void ablate::radiation::SurfaceRadiation::Initialize(const solver::Range& cellRange, ablate::domain::SubDomain& subDomain) { /** Declare some information associated with the field declarations */
     PetscReal* coord;
-    PetscInt* index;//!< Pointer to the coordinate field information
-    struct Virtualcoord* virtualcoord;                                                                                       //!< Pointer to the primary (virtual) coordinate field information
-    struct Identifier* identifier;                                                                                           //!< Pointer to the ray identifier information
+    PetscInt* index;                    //!< Pointer to the coordinate field information
+    struct Virtualcoord* virtualcoord;  //!< Pointer to the primary (virtual) coordinate field information
+    struct Identifier* identifier;      //!< Pointer to the ray identifier information
 
     /** Get the fields associated with the particle swarm so that they can be modified */
     DMSwarmGetField(radsearch, DMSwarmPICField_coor, nullptr, nullptr, (void**)&coord) >> checkError;

--- a/tests/unitTests/eos/radiationProperties/radiationSootAbsorptionTests.cpp
+++ b/tests/unitTests/eos/radiationProperties/radiationSootAbsorptionTests.cpp
@@ -22,8 +22,8 @@ TEST_P(SootTestFixture, ShouldProduceExpectedValuesForField) {
             ablateTesting::eos::MockEOS::CreateMockThermodynamicFunction([](const PetscReal conserved[], PetscReal* property) { *property = SootTestFixture::GetParam().temperatureIn; })));
     EXPECT_CALL(*eos, GetThermodynamicTemperatureFunction(ablate::eos::ThermodynamicProperty::Density, testing::_))
         .Times(::testing::Exactly(1))
-        .WillOnce(::testing::Return(
-            ablateTesting::eos::MockEOS::CreateMockThermodynamicTemperatureFunction([](const PetscReal conserved[], PetscReal temperature, PetscReal* property) { *property = SootTestFixture::GetParam().densityIn; })));
+        .WillOnce(::testing::Return(ablateTesting::eos::MockEOS::CreateMockThermodynamicTemperatureFunction(
+            [](const PetscReal conserved[], PetscReal temperature, PetscReal* property) { *property = SootTestFixture::GetParam().densityIn; })));
 
     auto sootModel = std::make_shared<ablate::eos::radiationProperties::SootMeanAbsorption>(eos);  //!< An instantiation of the Zimmer model (with options set to nullptr)
     auto absorptivityFunction = sootModel->GetRadiationPropertiesFunction(ablate::eos::radiationProperties::RadiationProperty::Absorptivity, SootTestFixture::GetParam().fields);

--- a/tests/unitTests/eos/radiationProperties/radiationSootAbsorptionTests.cpp
+++ b/tests/unitTests/eos/radiationProperties/radiationSootAbsorptionTests.cpp
@@ -20,10 +20,10 @@ TEST_P(SootTestFixture, ShouldProduceExpectedValuesForField) {
         .Times(::testing::Exactly(1))
         .WillOnce(::testing::Return(
             ablateTesting::eos::MockEOS::CreateMockThermodynamicFunction([](const PetscReal conserved[], PetscReal* property) { *property = SootTestFixture::GetParam().temperatureIn; })));
-    EXPECT_CALL(*eos, GetThermodynamicFunction(ablate::eos::ThermodynamicProperty::Density, testing::_))
+    EXPECT_CALL(*eos, GetThermodynamicTemperatureFunction(ablate::eos::ThermodynamicProperty::Density, testing::_))
         .Times(::testing::Exactly(1))
         .WillOnce(::testing::Return(
-            ablateTesting::eos::MockEOS::CreateMockThermodynamicFunction([](const PetscReal conserved[], PetscReal* property) { *property = SootTestFixture::GetParam().densityIn; })));
+            ablateTesting::eos::MockEOS::CreateMockThermodynamicTemperatureFunction([](const PetscReal conserved[], PetscReal temperature, PetscReal* property) { *property = SootTestFixture::GetParam().densityIn; })));
 
     auto sootModel = std::make_shared<ablate::eos::radiationProperties::SootMeanAbsorption>(eos);  //!< An instantiation of the Zimmer model (with options set to nullptr)
     auto absorptivityFunction = sootModel->GetRadiationPropertiesFunction(ablate::eos::radiationProperties::RadiationProperty::Absorptivity, SootTestFixture::GetParam().fields);

--- a/tests/unitTests/eos/radiationProperties/radiationZimmerTests.cpp
+++ b/tests/unitTests/eos/radiationProperties/radiationZimmerTests.cpp
@@ -20,10 +20,10 @@ TEST_P(ZimmerTestFixture, ShouldProduceExpectedValuesForField) {
         .Times(::testing::Exactly(1))
         .WillOnce(::testing::Return(
             ablateTesting::eos::MockEOS::CreateMockThermodynamicFunction([](const PetscReal conserved[], PetscReal* property) { *property = ZimmerTestFixture::GetParam().temperatureIn; })));
-    EXPECT_CALL(*eos, GetThermodynamicFunction(ablate::eos::ThermodynamicProperty::Density, testing::_))
+    EXPECT_CALL(*eos, GetThermodynamicTemperatureFunction(ablate::eos::ThermodynamicProperty::Density, testing::_))
         .Times(::testing::Exactly(1))
-        .WillOnce(::testing::Return(
-            ablateTesting::eos::MockEOS::CreateMockThermodynamicFunction([](const PetscReal conserved[], PetscReal* property) { *property = ZimmerTestFixture::GetParam().densityIn; })));
+        .WillOnce(::testing::Return(ablateTesting::eos::MockEOS::CreateMockThermodynamicTemperatureFunction(
+            [](const PetscReal conserved[], PetscReal temperature, PetscReal* property) { *property = ZimmerTestFixture::GetParam().densityIn; })));
 
     auto zimmerModel = std::make_shared<ablate::eos::radiationProperties::Zimmer>(eos);  //!< An instantiation of the Zimmer model (with options set to nullptr)
     auto absorptivityFunction = zimmerModel->GetRadiationPropertiesFunction(ablate::eos::radiationProperties::RadiationProperty::Absorptivity, ZimmerTestFixture::GetParam().fields);


### PR DESCRIPTION
Eliminates the calls to DMLocatePoints during the initialization by using the coordinate field that is provided by DMSwarm. (Speed up)

Changes non-constant absorption property density call to be temperature dependent. (Speed up and bug fix)