### PR TITLE
added verbose output to mpi test fixture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.9.62)
+project(ablateLibrary VERSION 0.9.63)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/tests/testingResources/MpiTestFixture.cpp
+++ b/tests/testingResources/MpiTestFixture.cpp
@@ -190,41 +190,50 @@ void testingResources::MpiTestFixture::CompareOutputFile(const std::string& expe
                 double expectedValue = expectedValues[v].size() > 1 ? stod(expectedValues[v].substr(1)) : NAN;
                 std::string actualValueString = actualValues[v];
 
-                switch (compareChar) {
-                    case '<':
-                        ASSERT_LT(std::stod(actualValueString), expectedValue) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        break;
-                    case '>':
-                        ASSERT_GT(std::stod(actualValueString), expectedValue) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        break;
-                    case '=':
-                        // check some special cases for double values
-                        if (std::isnan(expectedValue)) {
-                            ASSERT_TRUE(std::isnan(std::stod(actualValueString))) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        } else {
-                            ASSERT_DOUBLE_EQ(std::stod(actualValueString), expectedValue) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        }
-                        break;
-                    case '~':
-                        // is any number once trimmed
-                        ASSERT_TRUE(actualValueString.find_first_not_of(" \t\n\v\f\r") != std::string::npos) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        break;
-                    case '*':
-                        // is anything of length
-                        ASSERT_TRUE(!actualValueString.empty()) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        break;
-                    case 'z':
-                        // should be close to zer
-                        ASSERT_LT(std::abs(std::stod(actualValueString)), 1.0E-13) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
-                        break;
-                    case 'n': {
-                        // the value is near percent difference < 1E-3
-                        auto percentDifference = PetscAbs((std::stod(actualValueString) - expectedValue) / expectedValue);
-                        ASSERT_LT(percentDifference, 1.1E-3) << " the percent difference of (" << expectedValue << ", " << std::stod(actualValueString) << ") should be less than 1E-3 on line "
-                                                             << expectedLine << " of file " << expectedFileName;
-                    } break;
-                    default:
-                        FAIL() << "Unknown compare char " << compareChar << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                try {
+                    switch (compareChar) {
+                        case '<':
+                            ASSERT_LT(std::stod(actualValueString), expectedValue) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            break;
+                        case '>':
+                            ASSERT_GT(std::stod(actualValueString), expectedValue) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            break;
+                        case '=':
+                            // check some special cases for double values
+                            if (std::isnan(expectedValue)) {
+                                ASSERT_TRUE(std::isnan(std::stod(actualValueString))) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            } else {
+                                ASSERT_DOUBLE_EQ(std::stod(actualValueString), expectedValue) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            }
+                            break;
+                        case '~':
+                            // is any number once trimmed
+                            ASSERT_TRUE(actualValueString.find_first_not_of(" \t\n\v\f\r") != std::string::npos)
+                                << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            break;
+                        case '*':
+                            // is anything of length
+                            ASSERT_TRUE(!actualValueString.empty()) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            break;
+                        case 'z':
+                            // should be close to zer
+                            ASSERT_LT(std::abs(std::stod(actualValueString)), 1.0E-13) << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                            break;
+                        case 'n': {
+                            // the value is near percent difference < 1E-3
+                            auto percentDifference = PetscAbs((std::stod(actualValueString) - expectedValue) / expectedValue);
+                            ASSERT_LT(percentDifference, 1.1E-3) << " the percent difference of (" << expectedValue << ", " << std::stod(actualValueString) << ") should be less than 1E-3 on line "
+                                                                 << expectedLine << " of file " << expectedFileName;
+                        } break;
+                        default:
+                            FAIL() << "Unknown compare char " << compareChar << " on line (" << lineNumber << ") " << expectedLine << " of file " << expectedFileName;
+                    }
+                } catch (std::invalid_argument& invalidArgumentException) {
+                    throw std::invalid_argument("Invalid argument[" + std::to_string(v) + "] " + actualValueString + " for Comparison Character '" + compareChar + "' on line (" +
+                                                std::to_string(lineNumber) + ") " + expectedLine + " of file " + expectedFileName);
+                } catch (std::exception& exception) {
+                    throw std::invalid_argument("Parsing exception[" + std::to_string(v) + "] " + actualValueString + " for Comparison Character '" + compareChar + "' on line (" +
+                                                std::to_string(lineNumber) + ") " + expectedLine + " of file " + expectedFileName);
                 }
             }
         }


### PR DESCRIPTION
The error now looks like:
`Invalid argument[1] a for Comparison Character '<' on line (2) 	 euler: \[(.*), (.*), (.*), (.*)\]<expects> <0.01 <1000 <29 <1 of file outputs/compressibleFlow/compressibleCouetteFlow.txt`

This should close #382 