### PR TITLE
Memory Fix, Volumetric Limiter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.10.2)
+project(ablateLibrary VERSION 0.10.3)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -64,7 +64,11 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const Pe
         pCO = (density * UGC * YinCO * temperature) / (MWCO * 101325.);
 
         /** The resulting absorptivity is an average of species absorptivity weighted by partial pressure. */
-        *kappa = pCO2 * kappaCO2 + pH2O * kappaH2O + pCH4 * kappaCH4 + pCO * kappaCO;
+        *kappa = 0;
+        if (pCO2 > 1E-3 && kappaCO2 > 0) *kappa += pCO2 * kappaCO2;
+        if (pH2O > 1E-3 && kappaH2O > 0) *kappa += pH2O * kappaH2O;
+        if (pCH4 > 1E-3 && kappaCH4 > 0) *kappa += pCH4 * kappaCH4;
+        if (pCO > 1E-3 && kappaCO > 0) *kappa += pCO * kappaCO;
     }
     PetscFunctionReturn(0);
 }
@@ -126,7 +130,11 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerTemperatureFuncti
         pCO = (density * UGC * YinCO * temperature) / (MWCO * 101325.);
 
         /** The resulting absorptivity is an average of species absorptivity weighted by partial pressure. */
-        *kappa = pCO2 * kappaCO2 + pH2O * kappaH2O + pCH4 * kappaCH4 + pCO * kappaCO;
+        *kappa = 0;
+        if (pCO2 > 1E-3 && kappaCO2 > 0) *kappa += pCO2 * kappaCO2;
+        if (pH2O > 1E-3 && kappaH2O > 0) *kappa += pH2O * kappaH2O;
+        if (pCH4 > 1E-3 && kappaCH4 > 0) *kappa += pCH4 * kappaCH4;
+        if (pCO > 1E-3 && kappaCO > 0) *kappa += pCO * kappaCO;
     }
     PetscFunctionReturn(0);
 }

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -158,9 +158,11 @@ void ablate::radiation::Radiation::Setup(const solver::Range& cellRange, ablate:
     if (log) {
         log->Printf("Particles Setup\n");
     }
+    EndEvent();
 }
 
 void ablate::radiation::Radiation::Initialize(const solver::Range& cellRange, ablate::domain::SubDomain& subDomain) {
+    StartEvent("Radiation::Initialize");
     DM faceDM;
     const PetscScalar* faceGeomArray;
 
@@ -494,6 +496,7 @@ void ablate::radiation::Radiation::ParticleStep(ablate::domain::SubDomain& subDo
 }
 
 void ablate::radiation::Radiation::EvaluateGains(Vec solVec, ablate::domain::Field temperatureField, Vec auxVec) {
+    StartEvent("Radiation::EvaluateGains");
     /** Get the array of the solution vector. */
     const PetscScalar* solArray;
     DM solDm;
@@ -724,6 +727,7 @@ void ablate::radiation::Radiation::EvaluateGains(Vec solVec, ablate::domain::Fie
     VecRestoreArrayRead(solVec, &solArray);
     VecRestoreArrayRead(auxVec, &auxArray);
     VecRestoreArrayRead(faceGeomVec, &faceGeomArray) >> checkError;
+    EndEvent();
 }
 
 #include "registrar.hpp"

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -323,6 +323,7 @@ void ablate::radiation::Radiation::Solve(Vec solVec, ablate::domain::Field tempe
             absorptivityFunction.function(sol, *temperature, &kappa, absorptivityFunctionContext);
             GetFuelEmissivity(kappa);  //!< Adjusts the losses based on the material from which the radiation is emitted.
             losses *= 4 * ablate::utilities::Constants::sbc * *temperature * *temperature * *temperature * *temperature;
+            if (isinf(losses)) losses = ablate::utilities::Constants::huge;
             if (log) {
                 PetscReal centroid[3];
                 DMPlexComputeCellGeometryFVM(solDm, index, nullptr, centroid, nullptr) >> checkError;  //!< Reads the cell location from the current cell
@@ -710,6 +711,7 @@ void ablate::radiation::Radiation::EvaluateGains(Vec solVec, ablate::domain::Fie
                 origin[iCell].intensity += ((I0 * Kradd) + Isource) * abs(sin(theta)) * dTheta * dPhi * ldotn;  //!< Final ray calculation
             }
         }
+        if (isinf(origin[iCell].intensity)) origin[iCell].intensity = ablate::utilities::Constants::huge;
         origin[iCell].handler.clear();  //!< Eliminate all of the data being stored in the cell handler to free local memory
     }
 

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -655,7 +655,7 @@ void ablate::radiation::Radiation::EvaluateGains(Vec solVec, ablate::domain::Fie
             for (PetscInt nphi = 0; nphi < nPhi; nphi++) {
                 /** Now that we are iterating over every ray identifier in this local domain, we can get all of the particles that are associated with this ray.
                  * We will need to sort the rays in order of domain segment. We need to start at the end of the ray and go towards the beginning of the ray. */
-                Identifier loopid = {.rank = rank, .iCell = iCell, .ntheta = ntheta, .nphi = nphi, .nsegment = 1};  //!< Instantiate an identifier associated with this loop location.
+                Identifier loopid = {.rank = rank, .iCell = PetscShort(iCell), .ntheta = PetscShort(ntheta), .nphi = PetscShort(nphi), .nsegment = 1};  //!< Instantiate an identifier associated with this loop location.
 
                 /** Get the maximum nsegment by looping through all of the particles and searching for it.*/
                 bool pointfound = true;

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -417,7 +417,7 @@ void ablate::radiation::Radiation::ParticleStep(ablate::domain::SubDomain& subDo
              * */
             if (presence.count(identifier[ipart]) == 0) {  //!< IF THIS RAYS VECTOR IS EMPTY FOR THIS DOMAIN, THEN THE PARTICLE HAS NEVER BEEN HERE BEFORE. THEREFORE, ITERATE THE NDOMAINS BY 1.
                 identifier[ipart].nsegment++;                    //!< The particle has passed through another domain!
-                presence.insert(identifier[ipart]);
+                presence[identifier[ipart]] = true;
                 DMSwarmAddPoint(radsolve) >> checkError;  //!< Another solve particle is added here because the search particle has entered a new domain
 
                 DMSwarmGetLocalSize(radsolve,

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -38,24 +38,26 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
         PetscInt nphi;
         PetscInt nsegment;
 
-        bool operator==(const Identifier& comp) const {
+        /** Operator to check if 2 structs are equal */
+        inline bool operator==(const Identifier& comp) const {
             if (comp.rank != this->rank) return false;
-            if (comp.iCell != this->iCell) return false;
-            if (comp.ntheta != this->ntheta) return false;
-            if (comp.nphi != this->nphi) return false;
-            if (comp.nsegment != this->nsegment) return false;
-            return true;
+            else if (comp.iCell != this->iCell) return false;
+            else if (comp.ntheta != this->ntheta) return false;
+            else if (comp.nphi != this->nphi) return false;
+            else if (comp.nsegment != this->nsegment) return false;
+            else return true;
         };
-        bool operator<(const Identifier& comp) const {
-            if (comp.rank < this->rank) return true;
-            if (comp.iCell < this->iCell) return true;
-            if (comp.ntheta < this->ntheta) return true;
-            if (comp.nphi < this->nphi) return true;
-            if (comp.nsegment < this->nsegment) return true;
-            return false;
+
+        /** Operator to sort structs in a map */
+        inline bool operator<(const Identifier& comp) const {
+            if (comp.rank > this->rank) return true;
+            else if (comp.rank == this->rank && comp.iCell > this->iCell) return true;
+            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta > this->ntheta) return true;
+            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi > this->nphi) return true;
+            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi == this->nphi && comp.nsegment > this->nsegment) return true;
+            else return false;
         }
     };
-
 
     /** Carriers are attached to the solve particles and bring ray information from the local segments to the origin cells
      * They are transported directly from the segment to the origin. They carry only the values that the Segment computes and not the spatial information necessary to  */
@@ -75,7 +77,7 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
     };
 
     std::map<PetscInt, Origin> origin;
-    std::set<Identifier> presence;  //!< Map to track the local presence of search particles during the initialization
+    std::map<Identifier, bool> presence;  //!< Map to track the local presence of search particles during the initialization
 
     /** Returns the black body intensity for a given temperature and emissivity */
     static PetscReal FlameIntensity(PetscReal epsilon, PetscReal temperature);

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -33,19 +33,15 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
      * In the solve particle, nsegment remains constant as it ties the particle to its specific order in the ray */
     struct Identifier {
         PetscInt rank;
-        PetscShort iCell;
-        PetscShort ntheta;
-        PetscShort nphi;
-        PetscShort nsegment;
+        PetscInt iCell;
+        PetscInt ntheta;
+        PetscInt nphi;
+        PetscInt nsegment;
 
         /** Operator to check if 2 structs are equal */
         inline bool operator==(const Identifier& comp) const {
-            if (comp.rank != this->rank) return false;
-            else if (comp.iCell != this->iCell) return false;
-            else if (comp.ntheta != this->ntheta) return false;
-            else if (comp.nphi != this->nphi) return false;
-            else if (comp.nsegment != this->nsegment) return false;
-            else return true;
+            if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi == this->nphi && comp.nsegment == this->nsegment) return true;
+            else return false;
         };
 
         /** Operator to sort structs in a map */
@@ -62,17 +58,17 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
     /** Carriers are attached to the solve particles and bring ray information from the local segments to the origin cells
      * They are transported directly from the segment to the origin. They carry only the values that the Segment computes and not the spatial information necessary to  */
     struct Carrier {
-        PetscFloat Ij = 0;    //!< Black body source for the segment. Make sure that this is reset every solve after the value has been transported.
-        PetscFloat Krad = 1;  //!< Absorption for the segment. Make sure that this is reset every solve after the value has been transported.
-        PetscFloat I0 = 0;
+        PetscReal Ij = 0;    //!< Black body source for the segment. Make sure that this is reset every solve after the value has been transported.
+        PetscReal Krad = 1;  //!< Absorption for the segment. Make sure that this is reset every solve after the value has been transported.
+        PetscReal I0 = 0;
     };
 
     /** Each origin cell will need to retain local information given to it by the ray segments in order to compute the final intenisty.
      * This information will be owned by cell index and stored in a map of local cell indices.
      * */
     struct Origin {
-        PetscFloat intensity = 0;                 //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
-        PetscFloat net = 0;                       //!< The net radiation value including the losses. This is updated every pre-stage solve.
+        PetscReal intensity = 0;                 //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
+        PetscReal net = 0;                       //!< The net radiation value including the losses. This is updated every pre-stage solve.
         std::map<Identifier, Carrier> handler;  //!< Stores local carrier information
     };
 

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -41,18 +41,26 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
 
         /** Operator to check if 2 structs are equal */
         inline bool operator==(const Identifier& comp) const {
-            if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi == this->nphi && comp.nsegment == this->nsegment) return true;
-            else return false;
+            if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi == this->nphi && comp.nsegment == this->nsegment)
+                return true;
+            else
+                return false;
         };
 
         /** Operator to sort structs in a map */
         inline bool operator<(const Identifier& comp) const {
-            if (comp.rank > this->rank) return true;
-            else if (comp.rank == this->rank && comp.iCell > this->iCell) return true;
-            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta > this->ntheta) return true;
-            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi > this->nphi) return true;
-            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi == this->nphi && comp.nsegment > this->nsegment) return true;
-            else return false;
+            if (comp.rank > this->rank)
+                return true;
+            else if (comp.rank == this->rank && comp.iCell > this->iCell)
+                return true;
+            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta > this->ntheta)
+                return true;
+            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi > this->nphi)
+                return true;
+            else if (comp.rank == this->rank && comp.iCell == this->iCell && comp.ntheta == this->ntheta && comp.nphi == this->nphi && comp.nsegment > this->nsegment)
+                return true;
+            else
+                return false;
         }
     };
 
@@ -68,8 +76,8 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
      * This information will be owned by cell index and stored in a map of local cell indices.
      * */
     struct Origin {
-        PetscReal intensity = 0;                 //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
-        PetscReal net = 0;                       //!< The net radiation value including the losses. This is updated every pre-stage solve.
+        PetscReal intensity = 0;                //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
+        PetscReal net = 0;                      //!< The net radiation value including the losses. This is updated every pre-stage solve.
         std::map<Identifier, Carrier> handler;  //!< Stores local carrier information
     };
 
@@ -91,10 +99,14 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
      * Put safegaurds on the intensity read so that the rhs doesn't break if the time stepper decides to put absurd values into the eos for fun
      * */
     inline PetscReal GetIntensity(PetscInt iCell) {
-        if (abs(origin[iCell].net) < 1E10) return origin[iCell].net;
-        else if (origin[iCell].net > 1E10) return 1E10;
-        else if (origin[iCell].net < -1E10) return -1E10;
-        else return 0;
+        if (abs(origin[iCell].net) < 1E10)
+            return origin[iCell].net;
+        else if (origin[iCell].net > 1E10)
+            return 1E10;
+        else if (origin[iCell].net < -1E10)
+            return -1E10;
+        else
+            return 0;
     }
 
     /// Class Methods

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -40,9 +40,6 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
      * This information will be owned by cell index and stored in a map of local cell indices.
      * */
     struct Origin {
-        PetscReal I0 = 0;                        //!< Determing the initial ray intensity by grabbing the head cell of the furthest ray? There will need to be additional setup for this.
-        PetscReal Isource = 0;                   //!< Value that will be contributed to by every ray segment.
-        PetscReal Kradd = 1;                     //!< Value that will be contributed to by every ray segment.
         PetscReal intensity = 0;                 //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
         PetscReal net = 0;                       //!< The net radiation value including the losses. This is updated every pre-stage solve.
         std::map<std::string, Carrier> handler;  //!< Stores local carrier information
@@ -100,9 +97,6 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
     struct Segment {
         std::vector<PetscInt> cells;  //!< Stores the cell indices of the segment locally.
         std::vector<PetscReal> h;     //!< Stores the space steps of the segment locally.
-        PetscReal Ij = 0;             //!< Black body source for the segment. Make sure that this is reset every solve after the value has been transported.
-        PetscReal Krad = 1;           //!< Absorption for the segment. Make sure that this is reset every solve after the value has been transported.
-        PetscReal I0 = 0;
     };
 
     /** Identifiers are carrying by both the search and solve particles in order to associate them with their origins and ray segments

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -33,10 +33,10 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
      * In the solve particle, nsegment remains constant as it ties the particle to its specific order in the ray */
     struct Identifier {
         PetscInt rank;
-        PetscInt iCell;
-        PetscInt ntheta;
-        PetscInt nphi;
-        PetscInt nsegment;
+        PetscShort iCell;
+        PetscShort ntheta;
+        PetscShort nphi;
+        PetscShort nsegment;
 
         /** Operator to check if 2 structs are equal */
         inline bool operator==(const Identifier& comp) const {
@@ -62,17 +62,17 @@ class Radiation : protected utilities::Loggable<Radiation> {  //!< Cell solver p
     /** Carriers are attached to the solve particles and bring ray information from the local segments to the origin cells
      * They are transported directly from the segment to the origin. They carry only the values that the Segment computes and not the spatial information necessary to  */
     struct Carrier {
-        PetscReal Ij = 0;    //!< Black body source for the segment. Make sure that this is reset every solve after the value has been transported.
-        PetscReal Krad = 1;  //!< Absorption for the segment. Make sure that this is reset every solve after the value has been transported.
-        PetscReal I0 = 0;
+        PetscFloat Ij = 0;    //!< Black body source for the segment. Make sure that this is reset every solve after the value has been transported.
+        PetscFloat Krad = 1;  //!< Absorption for the segment. Make sure that this is reset every solve after the value has been transported.
+        PetscFloat I0 = 0;
     };
 
     /** Each origin cell will need to retain local information given to it by the ray segments in order to compute the final intenisty.
      * This information will be owned by cell index and stored in a map of local cell indices.
      * */
     struct Origin {
-        PetscReal intensity = 0;                 //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
-        PetscReal net = 0;                       //!< The net radiation value including the losses. This is updated every pre-stage solve.
+        PetscFloat intensity = 0;                 //!< The irradiation value that will be contributed to by every ray. This is updated every (pre-step && interval) gain evaluation.
+        PetscFloat net = 0;                       //!< The net radiation value including the losses. This is updated every pre-stage solve.
         std::map<Identifier, Carrier> handler;  //!< Stores local carrier information
     };
 

--- a/src/radiation/raySharingRadiation.cpp
+++ b/src/radiation/raySharingRadiation.cpp
@@ -46,7 +46,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
              * We should only iterate the identifier of the search particle (/ add a solver particle) if the point is valid in the domain and is being used
              * */
             if (presence.count(identifier[ipart]) == 0) {  //!< IF THIS RAYS VECTOR IS EMPTY FOR THIS DOMAIN, THEN THE PARTICLE HAS NEVER BEEN HERE BEFORE. THEREFORE, ITERATE THE NDOMAINS BY 1.
-                identifier[ipart].nsegment++;                    //!< The particle has passed through another domain!
+                identifier[ipart].nsegment++;              //!< The particle has passed through another domain!
                 presence[identifier[ipart]] = true;
                 DMSwarmAddPoint(radsolve) >> checkError;  //!< Another solve particle is added here because the search particle has entered a new domain
 
@@ -59,7 +59,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
                 PetscInt newpoint = nsolvepoints - 1;           //!< This must be replaced with the index of whatever particle there is. Maybe the last index?
                 solveidentifier[newpoint] = identifier[ipart];  //!< Give the particle an identifier which matches the particle it was created with
                 /** Create a new 'access identifier' and set it equal to the identifier of the current cell which the search particle is occupying */
-                access[newpoint].rank = rank;                      //!< The origin should be the current rank
+                access[newpoint].rank = rank;                        //!< The origin should be the current rank
                 access[newpoint].iCell = index[ipart];               //!< The index that the particle is currently occupying
                 access[newpoint].ntheta = identifier[ipart].ntheta;  //!< The angle of the ray we want
                 access[newpoint].nphi = identifier[ipart].nphi;      //!< The angle of the ray we want

--- a/src/radiation/raySharingRadiation.cpp
+++ b/src/radiation/raySharingRadiation.cpp
@@ -47,7 +47,7 @@ void ablate::radiation::RaySharingRadiation::ParticleStep(ablate::domain::SubDom
              * */
             if (presence.count(identifier[ipart]) == 0) {  //!< IF THIS RAYS VECTOR IS EMPTY FOR THIS DOMAIN, THEN THE PARTICLE HAS NEVER BEEN HERE BEFORE. THEREFORE, ITERATE THE NDOMAINS BY 1.
                 identifier[ipart].nsegment++;                    //!< The particle has passed through another domain!
-                presence.insert(identifier[ipart]);
+                presence[identifier[ipart]] = true;
                 DMSwarmAddPoint(radsolve) >> checkError;  //!< Another solve particle is added here because the search particle has entered a new domain
 
                 DMSwarmGetLocalSize(radsolve, &nsolvepoints) >> checkError;  //!< Recalculate the number of solve particles so that the last one in the list can be accessed.

--- a/src/utilities/constants.hpp
+++ b/src/utilities/constants.hpp
@@ -26,9 +26,6 @@ class Constants {
 
     //! A somewhat small number
     constexpr inline static PetscReal small = 1e-10;
-
-    //! A huge number
-    constexpr inline static PetscReal huge = 1e30;
 };
 }  // namespace ablate::utilities
 

--- a/src/utilities/constants.hpp
+++ b/src/utilities/constants.hpp
@@ -26,6 +26,9 @@ class Constants {
 
     //! A somewhat small number
     constexpr inline static PetscReal small = 1e-10;
+
+    //! A huge number
+    constexpr inline static PetscReal huge = 1e30;
 };
 }  // namespace ablate::utilities
 


### PR DESCRIPTION
Reduces the memory consumption of the radiation solver and protects the volumetric radiation from eos integration failures. Additional changes to enforce positivity in the absorption model.