### PR TITLE
cleaned up eos species names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.10.17)
+project(ablateLibrary VERSION 0.10.18)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/eos/chemTab.cpp
+++ b/src/eos/chemTab.cpp
@@ -81,7 +81,7 @@ ablate::eos::ChemTab::ChemTab(std::filesystem::path path) : ChemistryModel("abla
     referenceEOS = std::make_shared<ablate::eos::TChem>(mechanismPath);
 
     // make sure that the species list is the same
-    auto &referenceEOSSpecies = referenceEOS->GetSpecies();
+    auto &referenceEOSSpecies = referenceEOS->GetSpeciesVariables();
     if (referenceEOSSpecies.size() != speciesNames.size()) {
         throw std::invalid_argument("The ReferenceEOS species and chemTab species are expected to be the same.");
     }

--- a/src/eos/chemTab.hpp
+++ b/src/eos/chemTab.hpp
@@ -232,7 +232,7 @@ class ChemTab : public ChemistryModel {
 
     [[nodiscard]] const std::vector<std::string>& GetSpeciesVariables() const override { throw std::runtime_error(errorMessage); }
 
-    [[nodiscard]] const std::vector<std::string>& GetSpecies() const override { throw std::runtime_error(errorMessage); }
+    [[nodiscard]] const std::vector<std::string>& GetFieldFunctionProperties() const override { throw std::runtime_error(errorMessage); }
 
     [[nodiscard]] const std::vector<std::string>& GetProgressVariables() const override { throw std::runtime_error(errorMessage); }
 

--- a/src/eos/chemTab.hpp
+++ b/src/eos/chemTab.hpp
@@ -147,7 +147,7 @@ class ChemTab : public ChemistryModel, public std::enable_shared_from_this<ChemT
      * List of species used for the field function initialization.
      * @return
      */
-    [[nodiscard]] const std::vector<std::string>& GetSpecies() const override { return referenceEOS->GetSpecies(); }
+    [[nodiscard]] const std::vector<std::string>& GetFieldFunctionProperties() const override { return referenceEOS->GetFieldFunctionProperties(); }
 
     /**
      * As far as other parts of the code is concerned the chemTabEos does not expect species

--- a/src/eos/eos.hpp
+++ b/src/eos/eos.hpp
@@ -107,11 +107,11 @@ class EOS {
     [[nodiscard]] virtual const std::vector<std::string>& GetProgressVariables() const = 0;
 
     /**
-     * Species known by this equation of state.  This list is used for the FieldFunction calculations. This can be the same as the GetSpeciesVariables.
+     * Properties known by this equation of state used for the FieldFunction calculations. This can be the same as the GetSpeciesVariables.
      * species model functions
      * @return
      */
-    [[nodiscard]] virtual const std::vector<std::string>& GetSpecies() const { return GetSpeciesVariables(); }
+    [[nodiscard]] virtual const std::vector<std::string>& GetFieldFunctionProperties() const { return GetSpeciesVariables(); }
 
     /**
      * Support function for printing any eos

--- a/src/eos/tChem/sourceCalculator.cpp
+++ b/src/eos/tChem/sourceCalculator.cpp
@@ -26,7 +26,7 @@ void ablate::eos::tChem::SourceCalculator::ChemistryConstraints::Set(const std::
 
 ablate::eos::tChem::SourceCalculator::SourceCalculator(const std::vector<domain::Field>& fields, const std::shared_ptr<TChem> eosIn,
                                                        ablate::eos::tChem::SourceCalculator::ChemistryConstraints constraints, const solver::Range& cellRange)
-    : chemistryConstraints(constraints), eos(eosIn), numberSpecies(eosIn->GetSpecies().size()) {
+    : chemistryConstraints(constraints), eos(eosIn), numberSpecies(eosIn->GetSpeciesVariables().size()) {
     // determine the number of required cells
     std::size_t numberCells = cellRange.end - cellRange.start;
 

--- a/src/finiteVolume/compressibleFlowFields.cpp
+++ b/src/finiteVolume/compressibleFlowFields.cpp
@@ -21,9 +21,10 @@ std::vector<std::shared_ptr<ablate::domain::FieldDescription>> ablate::finiteVol
             VELOCITY_FIELD, VELOCITY_FIELD, std::vector<std::string>{"vel" + domain::FieldDescription::DIMENSION}, domain::FieldLocation::AUX, domain::FieldType::FVM, region, auxFieldOptions)};
 
     if (!eos->GetSpeciesVariables().empty()) {
+        flowFields.emplace_back(std::make_shared<domain::FieldDescription>(
+            DENSITY_YI_FIELD, DENSITY_YI_FIELD, eos->GetSpeciesVariables(), domain::FieldLocation::SOL, domain::FieldType::FVM, region, conservedFieldOptions));
         flowFields.emplace_back(
-            std::make_shared<domain::FieldDescription>(DENSITY_YI_FIELD, DENSITY_YI_FIELD, eos->GetSpecies(), domain::FieldLocation::SOL, domain::FieldType::FVM, region, conservedFieldOptions));
-        flowFields.emplace_back(std::make_shared<domain::FieldDescription>(YI_FIELD, YI_FIELD, eos->GetSpecies(), domain::FieldLocation::AUX, domain::FieldType::FVM, region, auxFieldOptions));
+            std::make_shared<domain::FieldDescription>(YI_FIELD, YI_FIELD, eos->GetSpeciesVariables(), domain::FieldLocation::AUX, domain::FieldType::FVM, region, auxFieldOptions));
     }
 
     if (!eos->GetProgressVariables().empty()) {

--- a/src/finiteVolume/fieldFunctions/compressibleFlowState.cpp
+++ b/src/finiteVolume/fieldFunctions/compressibleFlowState.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<ablate::mathFunctions::MathFunction> ablate::finiteVolume::field
         PetscCall(velocityFunction->GetPetscFunction()(dim, time, x, dim, velocity, velocityFunction->GetContext()));
 
         // compute the mass fraction at this location
-        std::vector<PetscReal> otherProperties(eos->GetSpecies().size());
+        std::vector<PetscReal> otherProperties(eos->GetFieldFunctionProperties().size());
         if (otherPropertyFunction) {
             PetscCall(
                 otherPropertyFunction->GetSolutionField().GetPetscFunction()(dim, time, x, otherProperties.size(), otherProperties.data(), otherPropertyFunction->GetSolutionField().GetContext()));

--- a/src/finiteVolume/fieldFunctions/massFractions.cpp
+++ b/src/finiteVolume/fieldFunctions/massFractions.cpp
@@ -6,7 +6,7 @@
 ablate::finiteVolume::fieldFunctions::MassFractions::MassFractions(std::shared_ptr<ablate::eos::EOS> eos, std::vector<std::shared_ptr<mathFunctions::FieldFunction>> massFractionFieldFunctionsIn)
     : ablate::mathFunctions::FieldFunction(eos::EOS::YI, std::make_shared<ablate::mathFunctions::FunctionPointer>(ablate::finiteVolume::fieldFunctions::MassFractions::ComputeYiFunction, this)),
       massFractionFieldFunctions(massFractionFieldFunctionsIn) {
-    const auto &species = eos->GetSpecies();
+    const auto &species = eos->GetFieldFunctionProperties();
 
     // Map the mass fractions to species
     massFractionFunctions.resize(species.size(), nullptr);

--- a/src/finiteVolume/processes/evTransport.cpp
+++ b/src/finiteVolume/processes/evTransport.cpp
@@ -43,7 +43,7 @@ void ablate::finiteVolume::processes::EVTransport::Setup(ablate::finiteVolume::F
         }
 
         if (transportModel) {
-            diffusionData.speciesSpeciesSensibleEnthalpy.resize(eos->GetSpecies().size());
+            diffusionData.speciesSpeciesSensibleEnthalpy.resize(eos->GetSpeciesVariables().size());
 
             diffusionData.diffFunction = transportModel->GetTransportFunction(eos::transport::TransportProperty::Diffusivity, flow.GetSubDomain().GetFields());
 

--- a/src/finiteVolume/processes/navierStokesTransport.cpp
+++ b/src/finiteVolume/processes/navierStokesTransport.cpp
@@ -23,7 +23,7 @@ ablate::finiteVolume::processes::NavierStokesTransport::NavierStokesTransport(co
         advectionData.fluxCalculatorFunction = fluxCalculator->GetFluxCalculatorFunction();
         advectionData.fluxCalculatorCtx = fluxCalculator->GetFluxCalculatorContext();
     }
-    advectionData.numberSpecies = (PetscInt)eos->GetSpecies().size();
+    advectionData.numberSpecies = (PetscInt)eos->GetSpeciesVariables().size();
 
     timeStepData.advectionData = &advectionData;
     timeStepData.pgs = std::move(pgs);

--- a/src/finiteVolume/processes/speciesTransport.cpp
+++ b/src/finiteVolume/processes/speciesTransport.cpp
@@ -11,7 +11,7 @@ ablate::finiteVolume::processes::SpeciesTransport::SpeciesTransport(std::shared_
 
     if (fluxCalculator) {
         // set the decode state function
-        advectionData.numberSpecies = (PetscInt)eos->GetSpecies().size();
+        advectionData.numberSpecies = (PetscInt)eos->GetSpeciesVariables().size();
 
         // extract the difference function from fluxDifferencer object
         advectionData.fluxCalculatorFunction = fluxCalculator->GetFluxCalculatorFunction();
@@ -20,14 +20,14 @@ ablate::finiteVolume::processes::SpeciesTransport::SpeciesTransport(std::shared_
 
     if (transportModel) {
         // set the eos functions
-        diffusionData.numberSpecies = (PetscInt)eos->GetSpecies().size();
-        diffusionData.speciesSpeciesSensibleEnthalpy.resize(eos->GetSpecies().size());
+        diffusionData.numberSpecies = (PetscInt)eos->GetSpeciesVariables().size();
+        diffusionData.speciesSpeciesSensibleEnthalpy.resize(eos->GetSpeciesVariables().size());
 
         // Add in the time stepping
         diffusionTimeStepData.stabilityFactor = parameters->Get<PetscReal>("speciesStabilityFactor", 0.0);
     }
 
-    numberSpecies = (PetscInt)eos->GetSpecies().size();
+    numberSpecies = (PetscInt)eos->GetSpeciesVariables().size();
 }
 
 void ablate::finiteVolume::processes::SpeciesTransport::Setup(ablate::finiteVolume::FiniteVolumeSolver &flow) {

--- a/src/monitors/mixtureFractionCalculator.cpp
+++ b/src/monitors/mixtureFractionCalculator.cpp
@@ -52,7 +52,7 @@ ablate::monitors::MixtureFractionCalculator::MixtureFractionCalculator(const std
     }
 
     // next determine mixFracMassCoeff
-    const auto& species = eos->GetSpecies();
+    const auto& species = eos->GetSpeciesVariables();
     zMixCoefficients.resize(species.size(), 0.0);
     for (std::size_t s = 0; s < species.size(); s++) {
         const auto& speciesName = species[s];
@@ -78,7 +78,7 @@ ablate::monitors::MixtureFractionCalculator::MixtureFractionCalculator(const std
 std::map<std::string, double> ablate::monitors::MixtureFractionCalculator::ToMassFractionMap(const std::shared_ptr<ablate::eos::EOS>& eos,
                                                                                              const std::shared_ptr<ablate::mathFunctions::FieldFunction>& massFractions) {
     // set up the memory
-    const auto& species = eos->GetSpecies();
+    const auto& species = eos->GetSpeciesVariables();
     std::vector<double> yiValues(species.size(), 0);
 
     // evaluate

--- a/src/monitors/mixtureFractionMonitor.cpp
+++ b/src/monitors/mixtureFractionMonitor.cpp
@@ -15,11 +15,12 @@ void ablate::monitors::MixtureFractionMonitor::Register(std::shared_ptr<solver::
         std::make_shared<domain::FieldDescription>("zMix", "zMix", domain::FieldDescription::ONECOMPONENT, domain::FieldLocation::SOL, domain::FieldType::FVM),
         std::make_shared<domain::FieldDescription>(ablate::finiteVolume::CompressibleFlowFields::YI_FIELD,
                                                    ablate::finiteVolume::CompressibleFlowFields::YI_FIELD,
-                                                   mixtureFractionCalculator->GetEos()->GetSpecies(),
+                                                   mixtureFractionCalculator->GetEos()->GetSpeciesVariables(),
                                                    domain::FieldLocation::SOL,
                                                    domain::FieldType::FVM),
         std::make_shared<domain::FieldDescription>("densityEnergySource", "energySource", domain::FieldDescription::ONECOMPONENT, domain::FieldLocation::SOL, domain::FieldType::FVM),
-        std::make_shared<domain::FieldDescription>("densityYiSource", "densityYiSource", mixtureFractionCalculator->GetEos()->GetSpecies(), domain::FieldLocation::SOL, domain::FieldType::FVM)};
+        std::make_shared<domain::FieldDescription>(
+            "densityYiSource", "densityYiSource", mixtureFractionCalculator->GetEos()->GetSpeciesVariables(), domain::FieldLocation::SOL, domain::FieldType::FVM)};
 
     // get the required function to compute density
     densityFunction = mixtureFractionCalculator->GetEos()->GetThermodynamicFunction(eos::ThermodynamicProperty::Density, solverIn->GetSubDomain().GetFields());

--- a/tests/unitTests/eos/chemTabTests.cpp
+++ b/tests/unitTests/eos/chemTabTests.cpp
@@ -78,7 +78,7 @@ TEST_P(ChemTabModelTestFixture, ShouldReturnCorrectSpeciesAndVariables) {
 
         // act
         auto actualSpeciesVariables = chemTabModel.GetSpeciesVariables();
-        auto actualSpecies = chemTabModel.GetSpecies();
+        auto actualSpecies = chemTabModel.GetFieldFunctionProperties();
         auto actualProgressVariables = chemTabModel.GetProgressVariables();
 
         // assert
@@ -307,7 +307,7 @@ TEST_P(ChemTabFieldFunctionTestFixture, ShouldComputeFieldFromYi) {
     // build a new reference eos
     auto metadata = YAML::LoadFile(std::filesystem::path(GetParam().modelPath) / "metadata.yaml");
     auto tchem = std::make_shared<ablate::eos::TChem>(std::filesystem::path(GetParam().modelPath) / metadata["mechanism"].as<std::string>());
-    auto yi = GetMassFraction(tchem->GetSpecies(), GetParam().yiMap);
+    auto yi = GetMassFraction(tchem->GetFieldFunctionProperties(), GetParam().yiMap);
 
     // get the test params
     const auto& params = GetParam();
@@ -345,7 +345,7 @@ TEST_P(ChemTabFieldFunctionTestFixture, ShouldComputeFieldFromProgressVariable) 
     // build a new reference eos
     auto metadata = YAML::LoadFile(std::filesystem::path(GetParam().modelPath) / "metadata.yaml");
     auto tchem = std::make_shared<ablate::eos::TChem>(std::filesystem::path(GetParam().modelPath) / metadata["mechanism"].as<std::string>());
-    auto yi = GetMassFraction(tchem->GetSpecies(), GetParam().yiMap);
+    auto yi = GetMassFraction(tchem->GetFieldFunctionProperties(), GetParam().yiMap);
 
     // get the test params
     const auto& params = GetParam();

--- a/tests/unitTests/eos/perfectGasTests.cpp
+++ b/tests/unitTests/eos/perfectGasTests.cpp
@@ -200,16 +200,15 @@ INSTANTIATE_TEST_SUITE_P(PerfectGasEOSTests, PGThermodynamicPropertyTestFixture,
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// EOS get species tests
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST(PerfectGasEOSTests, PerfectGasShouldReportNoSpeciesByDefault) {
+TEST(PerfectGasEOSTests, PerfectGasShouldReportNoSpeciesEctByDefault) {
     // arrange
     auto parameters = std::make_shared<ablate::parameters::MapParameters>();
     std::shared_ptr<ablate::eos::EOS> eos = std::make_shared<ablate::eos::PerfectGas>(parameters);
 
-    // act
-    auto species = eos->GetSpecies();
-
-    // assert
-    ASSERT_EQ(0, species.size());
+    // act //assert
+    ASSERT_EQ(0, eos->GetSpeciesVariables().size());
+    ASSERT_EQ(0, eos->GetFieldFunctionProperties().size());
+    ASSERT_EQ(0, eos->GetProgressVariables().size());
 }
 
 TEST(PerfectGasEOSTests, PerfectGasShouldReportSpeciesWhenProvided) {
@@ -218,7 +217,7 @@ TEST(PerfectGasEOSTests, PerfectGasShouldReportSpeciesWhenProvided) {
     std::shared_ptr<ablate::eos::EOS> eos = std::make_shared<ablate::eos::PerfectGas>(parameters, std::vector<std::string>{"N2", "H2"});
 
     // act
-    auto species = eos->GetSpecies();
+    auto species = eos->GetSpeciesVariables();
 
     // assert
     ASSERT_EQ(2, species.size());

--- a/tests/unitTests/eos/stiffenedGasTests.cpp
+++ b/tests/unitTests/eos/stiffenedGasTests.cpp
@@ -193,16 +193,15 @@ INSTANTIATE_TEST_SUITE_P(StiffenedGasEOSTests, SGThermodynamicPropertyTestFixtur
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// EOS get species tests
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST(StiffenedGasEOSTests, StiffenedGasShouldReportNoSpeciesByDefault) {
+TEST(StiffenedGasEOSTests, StiffenedGasShouldReportNoSpeciesEctByDefault) {
     // arrange
     auto parameters = std::make_shared<ablate::parameters::MapParameters>();
     std::shared_ptr<ablate::eos::EOS> eos = std::make_shared<ablate::eos::StiffenedGas>(parameters);
 
     // act
-    auto species = eos->GetSpecies();
-
-    // assert
-    ASSERT_EQ(0, species.size());
+    ASSERT_EQ(0, eos->GetSpeciesVariables().size());
+    ASSERT_EQ(0, eos->GetFieldFunctionProperties().size());
+    ASSERT_EQ(0, eos->GetProgressVariables().size());
 }
 
 TEST(StiffenedGasEOSTests, StiffenedGasShouldReportSpeciesWhenProvided) {
@@ -211,7 +210,7 @@ TEST(StiffenedGasEOSTests, StiffenedGasShouldReportSpeciesWhenProvided) {
     std::shared_ptr<ablate::eos::EOS> eos = std::make_shared<ablate::eos::StiffenedGas>(parameters, std::vector<std::string>{"N2", "H2"});
 
     // act
-    auto species = eos->GetSpecies();
+    auto species = eos->GetSpeciesVariables();
 
     // assert
     ASSERT_EQ(2, species.size());

--- a/tests/unitTests/eos/tChemTests.cpp
+++ b/tests/unitTests/eos/tChemTests.cpp
@@ -103,7 +103,7 @@ TEST_P(TChemGetSpeciesFixture, ShouldGetCorrectSpecies) {
     std::shared_ptr<ablate::eos::EOS> eos = std::make_shared<ablate::eos::TChem>(GetParam().mechFile, GetParam().thermoFile);
 
     // act
-    auto species = eos->GetSpecies();
+    auto species = eos->GetSpeciesVariables();
 
     // assert the output is as expected
     ASSERT_EQ(species, GetParam().expectedSpecies);
@@ -158,7 +158,7 @@ TEST_P(TCThermodynamicPropertyTestFixture, ShouldComputeProperty) {
                                                                                                                     return field.name == "euler";
                                                                                                                 })->offset);
     FillDensityMassFraction(*std::find_if(params.fields.begin(), params.fields.end(), [](const auto& field) { return field.name == "densityYi"; }),
-                            eos->GetSpecies(),
+                            eos->GetSpeciesVariables(),
                             params.yiMap,
                             params.conservedEulerValues[0],
                             conservedValues);
@@ -223,8 +223,8 @@ TEST_P(TCThermodynamicPropertyTestFixture, ShouldComputePropertyUsingMassFractio
                                                                                                                     return field.name == "euler";
                                                                                                                 })->offset);
     // Size and fill species
-    std::vector<PetscReal> yi(eos->GetSpecies().size(), 0.0);
-    FillMassFraction(eos->GetSpecies(), params.yiMap, yi);
+    std::vector<PetscReal> yi(eos->GetSpeciesVariables().size(), 0.0);
+    FillMassFraction(eos->GetSpeciesVariables(), params.yiMap, yi);
 
     // copy remove densityYi from the list in the params
     std::vector<ablate::domain::Field> fields;
@@ -571,12 +571,12 @@ class TChemFieldFunctionTestFixture : public testingResources::PetscTestFixture,
 TEST_P(TChemFieldFunctionTestFixture, ShouldComputeField) {
     // arrange
     std::shared_ptr<ablate::eos::EOS> eos = std::make_shared<ablate::eos::TChem>(GetParam().mechFile, GetParam().thermoFile);
-    auto yi = GetMassFraction(eos->GetSpecies(), GetParam().yiMap);
+    auto yi = GetMassFraction(eos->GetSpeciesVariables(), GetParam().yiMap);
 
     // get the test params
     const auto& params = GetParam();
     std::vector<PetscReal> actualEulerValue(params.expectedEulerValue.size(), NAN);
-    std::vector<PetscReal> actualDensityYiValue(eos->GetSpecies().size(), NAN);
+    std::vector<PetscReal> actualDensityYiValue(eos->GetSpeciesVariables().size(), NAN);
 
     // act
     auto stateEulerFunction = eos->GetFieldFunctionFunction("euler", params.property1, params.property2, {ablate::eos::EOS::YI});

--- a/tests/unitTests/eos/twoPhaseTests.cpp
+++ b/tests/unitTests/eos/twoPhaseTests.cpp
@@ -306,17 +306,16 @@ INSTANTIATE_TEST_SUITE_P(
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// EOS get species tests
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST(TwoPhaseEOSTests, TwoPhaseShouldReportNoSpeciesByDefault) {
+TEST(TwoPhaseEOSTests, TwoPhaseShouldReportNoSpeciesEctByDefault) {
     // arrange
     auto eos1 = nullptr;
     auto eos2 = nullptr;
     std::shared_ptr<ablate::eos::EOS> twoPhaseEos = std::make_shared<ablate::eos::TwoPhase>(eos1, eos2);
 
-    // act
-    auto species = twoPhaseEos->GetSpecies();
-
-    // assert
-    ASSERT_EQ(0, species.size());
+    // act // assert
+    ASSERT_EQ(0, twoPhaseEos->GetFieldFunctionProperties().size());
+    ASSERT_EQ(0, twoPhaseEos->GetSpeciesVariables().size());
+    ASSERT_EQ(0, twoPhaseEos->GetProgressVariables().size());
 }
 
 TEST(TwoPhaseEOSTests, TwoPhaseShouldReportSpeciesWhenProvided) {
@@ -328,7 +327,7 @@ TEST(TwoPhaseEOSTests, TwoPhaseShouldReportSpeciesWhenProvided) {
     std::shared_ptr<ablate::eos::EOS> twoPhaseEos = std::make_shared<ablate::eos::TwoPhase>(eos1, eos2);
 
     // act
-    auto species = twoPhaseEos->GetSpecies();
+    auto species = twoPhaseEos->GetSpeciesVariables();
 
     // assert
     ASSERT_EQ(3, species.size());

--- a/tests/unitTests/finiteVolume/compressibleFlowSpeciesDiffusionTests.cpp
+++ b/tests/unitTests/finiteVolume/compressibleFlowSpeciesDiffusionTests.cpp
@@ -123,8 +123,8 @@ TEST_P(CompressibleFlowSpeciesDiffusionTestFixture, ShouldConvergeToExactSolutio
             std::vector<std::shared_ptr<ablate::domain::FieldDescriptor>> fieldDescriptors = {
                 std::make_shared<ablate::domain::FieldDescription>(
                     "euler", "euler", std::vector<std::string>{"rho", "rhoE", "rhoVel" + domain::FieldDescription::DIMENSION}, domain::FieldLocation::SOL, domain::FieldType::FVM),
-                std::make_shared<ablate::domain::FieldDescription>("densityYi", "densityYi", eos->GetSpecies(), domain::FieldLocation::SOL, domain::FieldType::FVM),
-                std::make_shared<ablate::domain::FieldDescription>("Yi", "Yi", eos->GetSpecies(), domain::FieldLocation::AUX, domain::FieldType::FVM),
+                std::make_shared<ablate::domain::FieldDescription>("densityYi", "densityYi", eos->GetSpeciesVariables(), domain::FieldLocation::SOL, domain::FieldType::FVM),
+                std::make_shared<ablate::domain::FieldDescription>("Yi", "Yi", eos->GetSpeciesVariables(), domain::FieldLocation::AUX, domain::FieldType::FVM),
 
             };
 

--- a/tests/unitTests/finiteVolume/fieldFunctions/compressibleFlowStateTests.cpp
+++ b/tests/unitTests/finiteVolume/fieldFunctions/compressibleFlowStateTests.cpp
@@ -55,7 +55,7 @@ TEST_P(CompressibleFlowStateTestFixture, ShouldComputeCorrectMassFractions) {
     auto computeStateFunction = flowState.GetFieldFunction("densityYi");
 
     // act //assert
-    std::vector<PetscScalar> densityYi(eos->GetSpecies().size());
+    std::vector<PetscScalar> densityYi(eos->GetSpeciesVariables().size());
     ASSERT_EQ(0, computeStateFunction->GetPetscFunction()(location.size(), 0.0, &location[0], params.expectedEuler.size(), &densityYi[0], computeStateFunction->GetContext()));
     for (std::size_t i = 0; i < densityYi.size(); i++) {
         ASSERT_NEAR(densityYi[i], params.expectedDensityYi[i], 1E-3);

--- a/tests/unitTests/monitors/mixtureFractionCalculatorTests.cpp
+++ b/tests/unitTests/monitors/mixtureFractionCalculatorTests.cpp
@@ -28,11 +28,11 @@ TEST_P(MixtureFractionCalculatorFixture, ShouldComputeMixtureFraction) {
     // test each case
     for (const auto& [inputMassFractions, expectedValue] : GetParam().parameters) {
         // build a mixture fraction vector
-        std::vector<double> mixtureFraction(eos->GetSpecies().size());
+        std::vector<double> mixtureFraction(eos->GetSpeciesVariables().size());
         for (const auto& [species, yi] : inputMassFractions) {
-            auto location = std::find(eos->GetSpecies().begin(), eos->GetSpecies().end(), species);
-            if (location != eos->GetSpecies().end()) {
-                auto i = std::distance(eos->GetSpecies().begin(), location);
+            auto location = std::find(eos->GetSpeciesVariables().begin(), eos->GetSpeciesVariables().end(), species);
+            if (location != eos->GetSpeciesVariables().end()) {
+                auto i = std::distance(eos->GetSpeciesVariables().begin(), location);
                 mixtureFraction[i] = yi;
             }
         }
@@ -50,19 +50,19 @@ TEST_P(MixtureFractionCalculatorFixture, ShouldComputeMixtureFractionUsingFieldF
     ablate::monitors::MixtureFractionCalculator mixtureFractionCalculator(
         eos,
         std::make_shared<ablate::mathFunctions::FieldFunction>(
-            "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpecies(), GetParam().massFractionsFuel))),
+            "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpeciesVariables(), GetParam().massFractionsFuel))),
         std::make_shared<ablate::mathFunctions::FieldFunction>(
-            "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpecies(), GetParam().massFractionsOxidizer))),
+            "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpeciesVariables(), GetParam().massFractionsOxidizer))),
         GetParam().trackingElements);
 
     // test each case
     for (const auto& [inputMassFractions, expectedValue] : GetParam().parameters) {
         // build a mixture fraction vector
-        std::vector<double> mixtureFraction(eos->GetSpecies().size());
+        std::vector<double> mixtureFraction(eos->GetSpeciesVariables().size());
         for (const auto& [species, yi] : inputMassFractions) {
-            auto location = std::find(eos->GetSpecies().begin(), eos->GetSpecies().end(), species);
-            if (location != eos->GetSpecies().end()) {
-                auto i = std::distance(eos->GetSpecies().begin(), location);
+            auto location = std::find(eos->GetSpeciesVariables().begin(), eos->GetSpeciesVariables().end(), species);
+            if (location != eos->GetSpeciesVariables().end()) {
+                auto i = std::distance(eos->GetSpeciesVariables().begin(), location);
                 mixtureFraction[i] = yi;
             }
         }
@@ -119,9 +119,9 @@ TEST_P(MixtureFractionCalculatorExceptionFixture, ShouldThrowExceptionWithInvali
     ASSERT_THROW(ablate::monitors::MixtureFractionCalculator mixtureFractionCalculator(
                      eos,
                      std::make_shared<ablate::mathFunctions::FieldFunction>(
-                         "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpecies(), GetParam().massFractionsFuel))),
+                         "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpeciesVariables(), GetParam().massFractionsFuel))),
                      std::make_shared<ablate::mathFunctions::FieldFunction>(
-                         "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpecies(), GetParam().massFractionsOxidizer))),
+                         "yi", std::make_shared<ablate::mathFunctions::ConstantValue>(ablate::utilities::VectorUtilities::Fill(eos->GetSpeciesVariables(), GetParam().massFractionsOxidizer))),
                      GetParam().trackingElements);
                  , std::invalid_argument);
 }


### PR DESCRIPTION
This pr cleans up eos species names to make it clear what is the difference between:

- GetFieldFunctionProperties
- GetSpeciesVariables
- GetProgressVariables
