### PR TITLE
Zimmer Model Absorption Limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.10.21)
+project(ablateLibrary VERSION 0.10.22)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -39,7 +39,6 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const Pe
         kappaCO2 = kapparef * pow(10, kappaCO2);
 
         /** Computing the Planck mean absorption coefficient for CH4 and CO
-         * The relationship is different with enough significance to use different models above or below 750 K.
          * */
         for (int j = 0; j < 5; j++) {
             kappaCH4 += CH4_coeff.at(j) * pow(temperature, j);
@@ -107,7 +106,6 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerTemperatureFuncti
         kappaCO2 = kapparef * pow(10, kappaCO2);
 
         /** Computing the Planck mean absorption coefficient for CH4 and CO
-         * The relationship is different with enough significance to use different models above or below 750 K.
          * */
         for (int j = 0; j < 5; j++) {
             kappaCH4 += CH4_coeff.at(j) * pow(temperature, j);

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -2,7 +2,7 @@
 #include "math.h"
 
 ablate::eos::radiationProperties::Zimmer::Zimmer(std::shared_ptr<eos::EOS> eosIn, PetscReal upperLimitIn, PetscReal lowerLimitIn)
-    : eos(std::move(eosIn)), upperLimitStored((upperLimitIn = 0) ? 2500 : upperLimitIn), lowerLimitStored((lowerLimitIn = 0) ? 500 : lowerLimitIn) {}
+    : eos(std::move(eosIn)), upperLimitStored((upperLimitIn == 0) ? 2500 : upperLimitIn), lowerLimitStored((lowerLimitIn == 0) ? 500 : lowerLimitIn) {}
 
 PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const PetscReal *conserved, PetscReal *kappa, void *ctx) {
     PetscFunctionBeginUser;

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -20,6 +20,9 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const Pe
     if (density == 0) {
         *kappa = 0;
     } else {
+        if (temperature > 2500) temperature = 2500; //! Limit the model to only pull constants from below the upper end of the temperature.
+        if (temperature < 500) temperature = 500; //! Limit the model to only pull constants from above the lower end of the temperature.
+
         /** The Zimmer model uses a fit approximation of the absorptivity. This depends on the presence of four species which are present in combustion and shown below. */
         double kappaH2O = 0;
         double kappaCO2 = 0;
@@ -85,6 +88,9 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerTemperatureFuncti
     if (density == 0) {
         *kappa = 0;
     } else {
+        if (temperature > 2500) temperature = 2500; //! Limit the model to only pull constants from below the upper end of the temperature.
+        if (temperature < 500) temperature = 500; //! Limit the model to only pull constants from above the lower end of the temperature.
+
         /** The Zimmer model uses a fit approximation of the absorptivity. This depends on the presence of four species which are present in combustion and shown below. */
         double kappaH2O = 0;
         double kappaCO2 = 0;

--- a/src/eos/radiationProperties/zimmer.cpp
+++ b/src/eos/radiationProperties/zimmer.cpp
@@ -22,7 +22,7 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerFunction(const Pe
         *kappa = 0;
     } else {
         if (temperature > functionContext->upperLimit) temperature = functionContext->upperLimit;  //! Limit the model to only pull constants from below the upper end of the temperature.
-        if (temperature < functionContext->lowerLimit) temperature = functionContext->lowerLimit;    //! Limit the model to only pull constants from above the lower end of the temperature.
+        if (temperature < functionContext->lowerLimit) temperature = functionContext->lowerLimit;  //! Limit the model to only pull constants from above the lower end of the temperature.
 
         /** The Zimmer model uses a fit approximation of the absorptivity. This depends on the presence of four species which are present in combustion and shown below. */
         double kappaH2O = 0;
@@ -89,7 +89,7 @@ PetscErrorCode ablate::eos::radiationProperties::Zimmer::ZimmerTemperatureFuncti
         *kappa = 0;
     } else {
         if (temperature > functionContext->upperLimit) temperature = functionContext->upperLimit;  //! Limit the model to only pull constants from below the upper end of the temperature.
-        if (temperature < functionContext->lowerLimit) temperature = functionContext->lowerLimit;    //! Limit the model to only pull constants from above the lower end of the temperature.
+        if (temperature < functionContext->lowerLimit) temperature = functionContext->lowerLimit;  //! Limit the model to only pull constants from above the lower end of the temperature.
 
         /** The Zimmer model uses a fit approximation of the absorptivity. This depends on the presence of four species which are present in combustion and shown below. */
         double kappaH2O = 0;

--- a/src/eos/radiationProperties/zimmer.hpp
+++ b/src/eos/radiationProperties/zimmer.hpp
@@ -66,7 +66,7 @@ class Zimmer : public RadiationModel {
     static PetscErrorCode ZimmerTemperatureFunction(const PetscReal conserved[], PetscReal temperature, PetscReal* property, void* ctx);
 
    public:
-    explicit Zimmer(std::shared_ptr<eos::EOS> eosIn, PetscReal upperLimitIn, PetscReal lowerLimitIn);
+    explicit Zimmer(std::shared_ptr<eos::EOS> eosIn, PetscReal upperLimitIn = 0, PetscReal lowerLimitIn = 0);
     explicit Zimmer(const Zimmer&) = delete;
     void operator=(const Zimmer&) = delete;
 

--- a/src/eos/radiationProperties/zimmer.hpp
+++ b/src/eos/radiationProperties/zimmer.hpp
@@ -18,6 +18,9 @@ class Zimmer : public RadiationModel {
         PetscInt densityYiCOOffset;
         PetscInt densityYiCH4Offset;
 
+        PetscReal upperLimit;
+        PetscReal lowerLimit;
+
         const ThermodynamicFunction temperatureFunction;
         const ThermodynamicTemperatureFunction densityFunction;
     };
@@ -63,7 +66,7 @@ class Zimmer : public RadiationModel {
     static PetscErrorCode ZimmerTemperatureFunction(const PetscReal conserved[], PetscReal temperature, PetscReal* property, void* ctx);
 
    public:
-    explicit Zimmer(std::shared_ptr<eos::EOS> eosIn);
+    explicit Zimmer(std::shared_ptr<eos::EOS> eosIn, PetscReal upperLimitIn, PetscReal lowerLimitIn);
     explicit Zimmer(const Zimmer&) = delete;
     void operator=(const Zimmer&) = delete;
 
@@ -84,6 +87,9 @@ class Zimmer : public RadiationModel {
     [[nodiscard]] ThermodynamicTemperatureFunction GetRadiationPropertiesTemperatureFunction(RadiationProperty property, const std::vector<domain::Field>& fields) const override;
 
     PetscInt GetFieldComponentOffset(const std::string& str, const domain::Field& field) const;
+
+    PetscReal upperLimitStored;
+    PetscReal lowerLimitStored;
 };
 
 }  // namespace ablate::eos::radiationProperties

--- a/tests/unitTests/eos/radiationProperties/radiationZimmerTests.cpp
+++ b/tests/unitTests/eos/radiationProperties/radiationZimmerTests.cpp
@@ -8,6 +8,8 @@ struct ZimmerTestParameters {
     PetscReal temperatureIn;
     PetscReal densityIn;
     PetscReal expectedAbsorptivity;
+    PetscReal upperLimitTest;
+    PetscReal lowerLimitTest;
 };
 
 class ZimmerTestFixture : public ::testing::TestWithParam<ZimmerTestParameters> {};
@@ -25,7 +27,8 @@ TEST_P(ZimmerTestFixture, ShouldProduceExpectedValuesForField) {
         .WillOnce(::testing::Return(ablateTesting::eos::MockEOS::CreateMockThermodynamicTemperatureFunction(
             [](const PetscReal conserved[], PetscReal temperature, PetscReal* property) { *property = ZimmerTestFixture::GetParam().densityIn; })));
 
-    auto zimmerModel = std::make_shared<ablate::eos::radiationProperties::Zimmer>(eos);  //!< An instantiation of the Zimmer model (with options set to nullptr)
+    auto zimmerModel = std::make_shared<ablate::eos::radiationProperties::Zimmer>(
+        eos, ZimmerTestFixture::GetParam().upperLimitTest, ZimmerTestFixture::GetParam().lowerLimitTest);  //!< An instantiation of the Zimmer model (with options set to nullptr)
     auto absorptivityFunction = zimmerModel->GetRadiationPropertiesFunction(ablate::eos::radiationProperties::RadiationProperty::Absorptivity, ZimmerTestFixture::GetParam().fields);
 
     /** This section should set the fields with a certain distribution of material such that the absorptivity of that field produces a specific result */
@@ -47,38 +50,60 @@ INSTANTIATE_TEST_SUITE_P(RadationZimmerTests, ZimmerTestFixture,
                                                                 .conservedValues = {0.01, NAN, NAN, NAN, NAN, 0.0025, 0.0025, 0.0025, 0.0025},  //!< The Density Yi values live here
                                                                 .temperatureIn = 300.0,
                                                                 .densityIn = 0.01,  //!< The density is read through the equation of state above, not here
-                                                                .expectedAbsorptivity = 0.268109},
+                                                                .expectedAbsorptivity = 0.268109,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 1.0},
                                          /** A test with three valid species for the Zimmer model. */
                                          (ZimmerTestParameters){.fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                                                                            ablate::domain::Field{.name = "densityYi", .numberComponents = 4, .components = {"h2o", "CO2", "ch4"}, .offset = 5}},
                                                                 .conservedValues = {0.01, NAN, NAN, NAN, NAN, 0.0025, 0.0025, 0.0025},  //!< The Density Yi values live here
                                                                 .temperatureIn = 300.0,
                                                                 .densityIn = 1.1,
-                                                                .expectedAbsorptivity = 0.266579961079},
+                                                                .expectedAbsorptivity = 0.266579961079,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 1.0},
                                          /** A test with one valid species for the Zimmer model. */
                                          (ZimmerTestParameters){.fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                                                                            ablate::domain::Field{.name = "densityYi", .numberComponents = 4, .components = {"h2o"}, .offset = 5}},
                                                                 .conservedValues = {0.01, NAN, NAN, NAN, NAN, 0.0025},  //!< The Density Yi values live here
                                                                 .temperatureIn = 300.0,
                                                                 .densityIn = 1.1,
-                                                                .expectedAbsorptivity = 0.1230770},
+                                                                .expectedAbsorptivity = 0.1230770,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 1.0},
                                          /** A test with all valid species producing different results*/
                                          (ZimmerTestParameters){.fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                                                                            ablate::domain::Field{.name = "densityYi", .numberComponents = 4, .components = {"H2O", "co2", "ch4", "co"}, .offset = 5}},
                                                                 .conservedValues = {0.01, NAN, NAN, NAN, NAN, 0.0045, 0.0065, 0.0085, 0.0025},  //!< The Density Yi values live here
                                                                 .temperatureIn = 300.0,
                                                                 .densityIn = 0.01,
-                                                                .expectedAbsorptivity = 0.6132735699},
+                                                                .expectedAbsorptivity = 0.6132735699,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 1.0},
                                          /** A test with all valid species producing other different results*/
                                          (ZimmerTestParameters){.fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                                                                            ablate::domain::Field{.name = "densityYi", .numberComponents = 4, .components = {"h2o", "co2", "ch4", "CO"}, .offset = 5}},
                                                                 .conservedValues = {0.5, NAN, NAN, NAN, NAN, 0.0015, 0.0005, 0.0035, 0.0045},  //!< The Density Yi values live here
                                                                 .temperatureIn = 1200.0,
                                                                 .densityIn = 1.1,
-                                                                .expectedAbsorptivity = 0.2480760899},
+                                                                .expectedAbsorptivity = 0.2480760899,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 0.0},
+                                         /** This should compute zero. */
                                          (ZimmerTestParameters){.fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                                                                            ablate::domain::Field{.name = "densityYi", .numberComponents = 4, .components = {"H2O", "co2", "ch4", "co"}, .offset = 5}},
                                                                 .conservedValues = {0.00, NAN, NAN, NAN, NAN, 0.0, 0.0, 0.0, 0.0},  //!< The Density Yi values live here
                                                                 .temperatureIn = 300.0,
                                                                 .densityIn = 0.00,
-                                                                .expectedAbsorptivity = 0.0}));
+                                                                .expectedAbsorptivity = 0.0,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 1.0},
+                                         /** A test with the default limits to show the effect of the limits on the absorptivity computation */
+                                         (ZimmerTestParameters){.fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                                                                           ablate::domain::Field{.name = "densityYi", .numberComponents = 4, .components = {"H2O", "co2", "CH4", "co"}, .offset = 5}},
+                                                                .conservedValues = {0.01, NAN, NAN, NAN, NAN, 0.0025, 0.0025, 0.0025, 0.0025},  //!< The Density Yi values live here
+                                                                .temperatureIn = 300.0,
+                                                                .densityIn = 0.01,  //!< The density is read through the equation of state above, not here
+                                                                .expectedAbsorptivity = 0.30269715,
+                                                                .upperLimitTest = 0.0,
+                                                                .lowerLimitTest = 0.0}));


### PR DESCRIPTION
Truncates the Zimmer model to maintain reasonable absorption properties values beyond the valid limits of the correlation.