### PR TITLE
Calculates two phase CFL

### DIFF
--- a/.github/workflows/PullRequestWorkflow.yml
+++ b/.github/workflows/PullRequestWorkflow.yml
@@ -22,7 +22,7 @@ jobs:
         petscConfig: [ arch-ablate-opt ]
         tensorFlowConfig: [ "", "enabled_tf" ]
     runs-on: ${{ matrix.arch.runson }}
-    timeout-minutes: 90
+    timeout-minutes: 360
 
     steps:
       - name: Set up Docker Buildx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif ()
 
 # Set the project details
-project(ablateLibrary VERSION 0.10.31)
+project(ablateLibrary VERSION 0.10.32)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/eos/twoPhase.hpp
+++ b/src/eos/twoPhase.hpp
@@ -152,6 +152,9 @@ class TwoPhase : public EOS {  // , public std::enabled_shared_from_this<TwoPhas
     explicit TwoPhase(std::shared_ptr<eos::EOS> eos1, std::shared_ptr<eos::EOS> eos2);
     void View(std::ostream& stream) const override;
 
+    const std::shared_ptr<ablate::eos::EOS> GetEOSGas() const { return eos1; }
+    const std::shared_ptr<ablate::eos::EOS> GetEOSLiquid() const { return eos2; }
+
     ThermodynamicFunction GetThermodynamicFunction(ThermodynamicProperty property, const std::vector<domain::Field>& fields) const override;
 
     ThermodynamicTemperatureFunction GetThermodynamicTemperatureFunction(ThermodynamicProperty property, const std::vector<domain::Field>& fields) const override;

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include "eos/perfectGas.hpp"
 #include "eos/stiffenedGas.hpp"
+#include "eos/twoPhase.hpp"
 #include "parameters/emptyParameters.hpp"
 #include "finiteVolume/compressibleFlowFields.hpp"
 #include "flowProcess.hpp"
@@ -222,7 +223,9 @@ void ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Setup(ablate::fini
     // Currently, no option for species advection
     flow.RegisterRHSFunction(CompressibleFlowComputeEulerFlux, this, CompressibleFlowFields::EULER_FIELD, {VOLUME_FRACTION_FIELD, DENSITY_VF_FIELD, CompressibleFlowFields::EULER_FIELD}, {});
     flow.RegisterRHSFunction(CompressibleFlowComputeVFFlux, this, DENSITY_VF_FIELD, {VOLUME_FRACTION_FIELD, DENSITY_VF_FIELD, CompressibleFlowFields::EULER_FIELD}, {});
-    flow.RegisterComputeTimeStepFunction(ComputeTimeStep, &timeStepData, "cfl"); // ** new **
+    flow.RegisterComputeTimeStepFunction(ComputeCflTimeStep, &timeStepData, "cfl"); // ** new **
+    std::shared_ptr<ablate::eos::EOS> twoPhaseEos = std::make_shared<ablate::eos::TwoPhase>(eosGas,eosLiquid);
+    timeStepData.computeSpeedOfSound = twoPhaseEos->GetThermodynamicFunction(eos::ThermodynamicProperty::SpeedOfSound, flow.GetSubDomain().GetFields());
 
     // check to see if auxFieldUpdates needed to be added
     if (flow.GetSubDomain().ContainsField(CompressibleFlowFields::VELOCITY_FIELD)) {
@@ -304,7 +307,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Multipha
     PetscFunctionReturn(0);
 }
 
-double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx) {
+double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx) {
     // Get the dm and current solution vector
     DM dm;
     TSGetDM(ts, &dm) >> utilities::PetscUtilities::checkError;
@@ -313,7 +316,6 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
 
     // Get the flow param
     auto timeStepData = (TimeStepData*)ctx;
-//    auto advectionData = timeStepData->advectionData;
 
     // Get the fv geom
     PetscReal minCellRadius;
@@ -350,8 +352,6 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
             PetscReal rho = euler[CompressibleFlowFields::RHO];
 
             // Get the speed of sound from the eos
-//            PetscReal temperature;
-//            advectionData->computeTemperature.function(conserved, &temperature, advectionData->computeTemperature.context.get()) >> checkError;
             PetscReal a;
             timeStepData->computeSpeedOfSound.function(conserved, &a, timeStepData->computeSpeedOfSound.context.get()) >> utilities::PetscUtilities::checkError;
 

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -327,12 +327,6 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
     // Get field location for euler and densityYi
     auto eulerId = flow.GetSubDomain().GetField("euler").id;
 
-    // Get alpha if provided
-    PetscReal pgsAlpha = 1.0;
-    if (timeStepData->pgs) {
-        pgsAlpha = timeStepData->pgs->GetAlpha();
-    }
-
     // March over each cell
     PetscReal dtMin = 1000.0;
     for (PetscInt c = cellRange.start; c < cellRange.end; ++c) {
@@ -356,7 +350,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
             for (PetscInt d = 0; d < dim; d++) {
                 velSum += PetscAbsReal(euler[CompressibleFlowFields::RHOU + d]) / rho;
             }
-            PetscReal dt = advectionData->cfl * dx / (a / pgsAlpha + velSum);
+            PetscReal dt = advectionData->cfl * dx / (a + velSum);
 
             dtMin = PetscMin(dtMin, dt);
         }

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -336,7 +336,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeSt
     const PetscReal dx = 2.0 * minCellRadius;
 
     // Get field location for euler and densityYi
-    auto eulerId = flow.GetSubDomain().GetField("euler").id;
+    auto eulerId = flow.GetSubDomain().GetField(ablate::finiteVolume::CompressibleFlowFields::EULER_FIELD).id;
 
     // March over each cell
     PetscReal dtMin = 1000.0;

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -304,7 +304,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
 
     // Get the flow param
     auto timeStepData = (TimeStepData*)ctx;
-    auto advectionData = timeStepData->advectionData;
+//    auto advectionData = timeStepData->advectionData;
 
     // Get the fv geom
     PetscReal minCellRadius;
@@ -341,16 +341,16 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
             PetscReal rho = euler[CompressibleFlowFields::RHO];
 
             // Get the speed of sound from the eos
-            PetscReal temperature;
-            advectionData->computeTemperature.function(conserved, &temperature, advectionData->computeTemperature.context.get()) >> checkError;
+//            PetscReal temperature;
+//            advectionData->computeTemperature.function(conserved, &temperature, advectionData->computeTemperature.context.get()) >> checkError;
             PetscReal a;
-            advectionData->computeSpeedOfSound.function(conserved, temperature, &a, advectionData->computeSpeedOfSound.context.get()) >> checkError;
+            timeStepData->computeSpeedOfSound.function(conserved, &a, timeStepData->computeSpeedOfSound.context.get()) >> checkError;
 
             PetscReal velSum = 0.0;
             for (PetscInt d = 0; d < dim; d++) {
                 velSum += PetscAbsReal(euler[CompressibleFlowFields::RHOU + d]) / rho;
             }
-            PetscReal dt = advectionData->cfl * dx / (a + velSum);
+            PetscReal dt = timeStepData->cfl * dx / (a + velSum);
 
             dtMin = PetscMin(dtMin, dt);
         }

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -4,9 +4,9 @@
 #include "eos/perfectGas.hpp"
 #include "eos/stiffenedGas.hpp"
 #include "eos/twoPhase.hpp"
-#include "parameters/emptyParameters.hpp"
 #include "finiteVolume/compressibleFlowFields.hpp"
 #include "flowProcess.hpp"
+#include "parameters/emptyParameters.hpp"
 
 static inline void NormVector(PetscInt dim, const PetscReal *in, PetscReal *out) {
     PetscReal mag = 0.0;
@@ -193,7 +193,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::FormJaco
 }
 
 ablate::finiteVolume::processes::TwoPhaseEulerAdvection::TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosGas, std::shared_ptr<eos::EOS> eosLiquid,
-                                                                                const std::shared_ptr<parameters::Parameters>& parametersIn,
+                                                                                const std::shared_ptr<parameters::Parameters> &parametersIn,
                                                                                 std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas,
                                                                                 std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid,
                                                                                 std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas,
@@ -223,8 +223,8 @@ void ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Setup(ablate::fini
     // Currently, no option for species advection
     flow.RegisterRHSFunction(CompressibleFlowComputeEulerFlux, this, CompressibleFlowFields::EULER_FIELD, {VOLUME_FRACTION_FIELD, DENSITY_VF_FIELD, CompressibleFlowFields::EULER_FIELD}, {});
     flow.RegisterRHSFunction(CompressibleFlowComputeVFFlux, this, DENSITY_VF_FIELD, {VOLUME_FRACTION_FIELD, DENSITY_VF_FIELD, CompressibleFlowFields::EULER_FIELD}, {});
-    flow.RegisterComputeTimeStepFunction(ComputeCflTimeStep, &timeStepData, "cfl"); // ** new **
-    std::shared_ptr<ablate::eos::EOS> twoPhaseEos = std::make_shared<ablate::eos::TwoPhase>(eosGas,eosLiquid);
+    flow.RegisterComputeTimeStepFunction(ComputeCflTimeStep, &timeStepData, "cfl");
+    std::shared_ptr<ablate::eos::EOS> twoPhaseEos = std::make_shared<ablate::eos::TwoPhase>(eosGas, eosLiquid);
     timeStepData.computeSpeedOfSound = twoPhaseEos->GetThermodynamicFunction(eos::ThermodynamicProperty::SpeedOfSound, flow.GetSubDomain().GetFields());
 
     // check to see if auxFieldUpdates needed to be added
@@ -307,7 +307,7 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Multipha
     PetscFunctionReturn(0);
 }
 
-double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx) {
+double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver &flow, void *ctx) {
     // Get the dm and current solution vector
     DM dm;
     TSGetDM(ts, &dm) >> utilities::PetscUtilities::checkError;
@@ -315,7 +315,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeSt
     TSGetSolution(ts, &v) >> utilities::PetscUtilities::checkError;
 
     // Get the flow param
-    auto timeStepData = (TimeStepData*)ctx;
+    auto timeStepData = (TimeStepData *)ctx;
 
     // Get the fv geom
     PetscReal minCellRadius;
@@ -325,7 +325,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeSt
     solver::Range cellRange;
     flow.GetCellRange(cellRange);
 
-    const PetscScalar* x;
+    const PetscScalar *x;
     VecGetArrayRead(v, &x) >> utilities::PetscUtilities::checkError;
 
     // Get the dim from the dm
@@ -343,8 +343,8 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeCflTimeSt
     for (PetscInt c = cellRange.start; c < cellRange.end; ++c) {
         PetscInt cell = cellRange.points ? cellRange.points[c] : c;
 
-        const PetscReal* euler;
-        const PetscReal* conserved = NULL;
+        const PetscReal *euler;
+        const PetscReal *conserved = NULL;
         DMPlexPointGlobalFieldRead(dm, cell, eulerId, x, &euler) >> utilities::PetscUtilities::checkError;
         DMPlexPointGlobalRead(dm, cell, x, &conserved) >> utilities::PetscUtilities::checkError;
 
@@ -1262,6 +1262,6 @@ void ablate::finiteVolume::processes::TwoPhaseEulerAdvection::StiffenedGasStiffe
 
 #include "registrar.hpp"
 REGISTER(ablate::finiteVolume::processes::Process, ablate::finiteVolume::processes::TwoPhaseEulerAdvection, "", ARG(ablate::eos::EOS, "eosGas", ""), ARG(ablate::eos::EOS, "eosLiquid", ""),
-         OPT(ablate::parameters::Parameters, "parameters", "the parameters used by advection/diffusion: cfl(.5), conductionStabilityFactor(0), viscousStabilityFactor(0)"),
-         ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorGasGas", ""), ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorGasLiquid", ""),
-         ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorLiquidGas", ""), ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorLiquidLiquid", ""));
+         OPT(ablate::parameters::Parameters, "parameters", "the parameters used by advection: cfl(.5)"), ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorGasGas", ""),
+         ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorGasLiquid", ""), ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorLiquidGas", ""),
+         ARG(ablate::finiteVolume::fluxCalculator::FluxCalculator, "fluxCalculatorLiquidLiquid", ""));

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.cpp
@@ -298,9 +298,9 @@ PetscErrorCode ablate::finiteVolume::processes::TwoPhaseEulerAdvection::Multipha
 double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx) {
     // Get the dm and current solution vector
     DM dm;
-    TSGetDM(ts, &dm) >> ablate::utilities::PetscUtilities::checkError;
+    TSGetDM(ts, &dm) >> utilities::PetscUtilities::checkError;
     Vec v;
-    TSGetSolution(ts, &v) >> ablate::utilities::PetscUtilities::checkError;
+    TSGetSolution(ts, &v) >> utilities::PetscUtilities::checkError;
 
     // Get the flow param
     auto timeStepData = (TimeStepData*)ctx;
@@ -308,18 +308,18 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
 
     // Get the fv geom
     PetscReal minCellRadius;
-    DMPlexGetGeometryFVM(dm, NULL, NULL, &minCellRadius) >> ablate::utilities::PetscUtilities::checkError;
+    DMPlexGetGeometryFVM(dm, NULL, NULL, &minCellRadius) >> utilities::PetscUtilities::checkError;
 
     // Get the valid cell range over this region
     solver::Range cellRange;
     flow.GetCellRange(cellRange);
 
     const PetscScalar* x;
-    VecGetArrayRead(v, &x) >> ablate::utilities::PetscUtilities::checkError;
+    VecGetArrayRead(v, &x) >> utilities::PetscUtilities::checkError;
 
     // Get the dim from the dm
     PetscInt dim;
-    DMGetDimension(dm, &dim) >> ablate::utilities::PetscUtilities::checkError;
+    DMGetDimension(dm, &dim) >> utilities::PetscUtilities::checkError;
 
     // assume the smallest cell is the limiting factor for now
     const PetscReal dx = 2.0 * minCellRadius;
@@ -334,8 +334,8 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
 
         const PetscReal* euler;
         const PetscReal* conserved = NULL;
-        DMPlexPointGlobalFieldRead(dm, cell, eulerId, x, &euler) >> ablate::utilities::PetscUtilities::checkError;
-        DMPlexPointGlobalRead(dm, cell, x, &conserved) >> ablate::utilities::PetscUtilities::checkError;
+        DMPlexPointGlobalFieldRead(dm, cell, eulerId, x, &euler) >> utilities::PetscUtilities::checkError;
+        DMPlexPointGlobalRead(dm, cell, x, &conserved) >> utilities::PetscUtilities::checkError;
 
         if (euler) {  // must be real cell and not ghost
             PetscReal rho = euler[CompressibleFlowFields::RHO];
@@ -344,7 +344,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
 //            PetscReal temperature;
 //            advectionData->computeTemperature.function(conserved, &temperature, advectionData->computeTemperature.context.get()) >> checkError;
             PetscReal a;
-            timeStepData->computeSpeedOfSound.function(conserved, &a, timeStepData->computeSpeedOfSound.context.get()) >> ablate::utilities::PetscUtilities::checkError;
+            timeStepData->computeSpeedOfSound.function(conserved, &a, timeStepData->computeSpeedOfSound.context.get()) >> utilities::PetscUtilities::checkError;
 
             PetscReal velSum = 0.0;
             for (PetscInt d = 0; d < dim; d++) {
@@ -355,7 +355,7 @@ double ablate::finiteVolume::processes::TwoPhaseEulerAdvection::ComputeTimeStep(
             dtMin = PetscMin(dtMin, dt);
         }
     }
-    VecRestoreArrayRead(v, &x) >> ablate::utilities::PetscUtilities::checkError;
+    VecRestoreArrayRead(v, &x) >> utilities::PetscUtilities::checkError;
     flow.RestoreRange(cellRange);
     return dtMin;
 }

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
@@ -16,6 +16,12 @@ class TwoPhaseEulerAdvection : public Process {
     inline const static std::string VOLUME_FRACTION_FIELD = eos::TwoPhase::VF;
     inline const static std::string DENSITY_VF_FIELD = ablate::finiteVolume::CompressibleFlowFields::CONSERVED + VOLUME_FRACTION_FIELD;
 
+    struct TimeStepData {
+        PetscReal cfl;
+        eos::ThermodynamicFunction computeSpeedOfSound; // **change**, this needs to twoPhase EOS
+    };
+    TimeStepData timeStepData;
+
    private:
     struct DecodeDataStructGas {
         PetscReal etot;

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
@@ -164,8 +164,9 @@ class TwoPhaseEulerAdvection : public Process {
                                       PetscReal *MG, PetscReal *ML, PetscReal *p, PetscReal *T, PetscReal *alpha) override;
     };
 
-    const std::shared_ptr<eos::EOS> eosGas;
-    const std::shared_ptr<eos::EOS> eosLiquid;
+    const std::shared_ptr<eos::EOS> eosTwoPhase;
+    std::shared_ptr<eos::EOS> eosGas;
+    std::shared_ptr<eos::EOS> eosLiquid;
     const std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas;
     const std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid;
     const std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas;
@@ -186,9 +187,9 @@ class TwoPhaseEulerAdvection : public Process {
     static PetscErrorCode UpdateAuxVelocityField2Gas(PetscReal time, PetscInt dim, const PetscFVCellGeom *cellGeom, const PetscInt uOff[], const PetscScalar *conservedValues, const PetscInt aOff[],
                                                      PetscScalar *auxField, void *ctx);
 
-    TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosGas, std::shared_ptr<eos::EOS> eosLiquid, const std::shared_ptr<parameters::Parameters> &parameters,
-                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid,
-                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidLiquid);
+    TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosTwoPhase, const std::shared_ptr<parameters::Parameters> &parameters, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas,
+                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas,
+                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidLiquid);
     void Setup(ablate::finiteVolume::FiniteVolumeSolver &flow) override;
 
    private:

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
@@ -186,6 +186,9 @@ class TwoPhaseEulerAdvection : public Process {
     void Setup(ablate::finiteVolume::FiniteVolumeSolver &flow) override;
 
    private:
+    // static function to compute time step for twoPhase euler advection
+    static double ComputeTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx);
+
     static PetscErrorCode CompressibleFlowComputeEulerFlux(PetscInt dim, const PetscFVFaceGeom *fg, const PetscInt uOff[], const PetscScalar fieldL[], const PetscScalar fieldR[],
                                                            const PetscInt aOff[], const PetscScalar auxL[], const PetscScalar auxR[], PetscScalar *flux, void *ctx);
     static PetscErrorCode CompressibleFlowComputeVFFlux(PetscInt dim, const PetscFVFaceGeom *fg, const PetscInt uOff[], const PetscScalar fieldL[], const PetscScalar fieldR[], const PetscInt aOff[],

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
@@ -193,7 +193,7 @@ class TwoPhaseEulerAdvection : public Process {
 
    private:
     // static function to compute time step for twoPhase euler advection
-    static double ComputeTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx);
+    static double ComputeCflTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx);
 
     static PetscErrorCode CompressibleFlowComputeEulerFlux(PetscInt dim, const PetscFVFaceGeom *fg, const PetscInt uOff[], const PetscScalar fieldL[], const PetscScalar fieldR[],
                                                            const PetscInt aOff[], const PetscScalar auxL[], const PetscScalar auxR[], PetscScalar *flux, void *ctx);

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
@@ -186,7 +186,7 @@ class TwoPhaseEulerAdvection : public Process {
     static PetscErrorCode UpdateAuxVelocityField2Gas(PetscReal time, PetscInt dim, const PetscFVCellGeom *cellGeom, const PetscInt uOff[], const PetscScalar *conservedValues, const PetscInt aOff[],
                                                      PetscScalar *auxField, void *ctx);
 
-    TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosGas, std::shared_ptr<eos::EOS> eosLiquid, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas,
+    TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosGas, std::shared_ptr<eos::EOS> eosLiquid, const std::shared_ptr<parameters::Parameters>& parameters, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas,
                            std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas,
                            std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidLiquid);
     void Setup(ablate::finiteVolume::FiniteVolumeSolver &flow) override;

--- a/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
+++ b/src/finiteVolume/processes/twoPhaseEulerAdvection.hpp
@@ -18,7 +18,7 @@ class TwoPhaseEulerAdvection : public Process {
 
     struct TimeStepData {
         PetscReal cfl;
-        eos::ThermodynamicFunction computeSpeedOfSound; // **change**, this needs to twoPhase EOS
+        eos::ThermodynamicFunction computeSpeedOfSound;
     };
     TimeStepData timeStepData;
 
@@ -186,14 +186,14 @@ class TwoPhaseEulerAdvection : public Process {
     static PetscErrorCode UpdateAuxVelocityField2Gas(PetscReal time, PetscInt dim, const PetscFVCellGeom *cellGeom, const PetscInt uOff[], const PetscScalar *conservedValues, const PetscInt aOff[],
                                                      PetscScalar *auxField, void *ctx);
 
-    TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosGas, std::shared_ptr<eos::EOS> eosLiquid, const std::shared_ptr<parameters::Parameters>& parameters, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas,
-                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas,
-                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidLiquid);
+    TwoPhaseEulerAdvection(std::shared_ptr<eos::EOS> eosGas, std::shared_ptr<eos::EOS> eosLiquid, const std::shared_ptr<parameters::Parameters> &parameters,
+                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasGas, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorGasLiquid,
+                           std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidGas, std::shared_ptr<fluxCalculator::FluxCalculator> fluxCalculatorLiquidLiquid);
     void Setup(ablate::finiteVolume::FiniteVolumeSolver &flow) override;
 
    private:
     // static function to compute time step for twoPhase euler advection
-    static double ComputeCflTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver& flow, void* ctx);
+    static double ComputeCflTimeStep(TS ts, ablate::finiteVolume::FiniteVolumeSolver &flow, void *ctx);
 
     static PetscErrorCode CompressibleFlowComputeEulerFlux(PetscInt dim, const PetscFVFaceGeom *fg, const PetscInt uOff[], const PetscScalar fieldL[], const PetscScalar fieldR[],
                                                            const PetscInt aOff[], const PetscScalar auxL[], const PetscScalar auxR[], PetscScalar *flux, void *ctx);

--- a/tests/integrationTests/inputs/shocktube/shockTube1DSod_AirWater.yaml
+++ b/tests/integrationTests/inputs/shocktube/shockTube1DSod_AirWater.yaml
@@ -49,15 +49,16 @@ solver: !ablate::finiteVolume::FiniteVolumeSolver
   id: SOD Problem
   processes:
     - !ablate::finiteVolume::processes::TwoPhaseEulerAdvection
-      eosGas: !ablate::eos::PerfectGas &eosAir
-        parameters:
-          gamma: 1.4
-          Rgas: 287.0
-      eosLiquid: !ablate::eos::StiffenedGas &eosWater
-        parameters:
-          gamma: 1.932
-          Cp: 8095.08
-          p0: 1164500000.0
+      eos: !ablate::eos::TwoPhase
+        eos1: !ablate::eos::PerfectGas &eosAir
+          parameters:
+            gamma: 1.4
+            Rgas: 287.0
+        eos2: !ablate::eos::StiffenedGas &eosWater
+          parameters:
+            gamma: 1.932
+            Cp: 8095.08
+            p0: 1164500000.0
       fluxCalculatorGasGas: !ablate::finiteVolume::fluxCalculator::RiemannStiff
         eosL: *eosAir
         eosR: *eosAir

--- a/tests/integrationTests/inputs/shocktube/shockTube2Gas2D.yaml
+++ b/tests/integrationTests/inputs/shocktube/shockTube2Gas2D.yaml
@@ -54,14 +54,15 @@ solver: !ablate::finiteVolume::FiniteVolumeSolver
   id: SOD Problem
   processes:
     - !ablate::finiteVolume::processes::TwoPhaseEulerAdvection
-      eosGas: !ablate::eos::PerfectGas &eosAir
-        parameters: # air
-          gamma: 1.4
-          Rgas: 287.0
-      eosLiquid: !ablate::eos::PerfectGas &eosArgon
-        parameters: # argon
-          gamma: 1.67
-          Rgas: 208.1
+      eos: !ablate::eos::TwoPhase
+        eos1: !ablate::eos::PerfectGas &eosAir
+          parameters: # air
+            gamma: 1.4
+            Rgas: 287.0
+        eos2: !ablate::eos::PerfectGas &eosArgon
+          parameters: # argon
+            gamma: 1.67
+            Rgas: 208.1
       fluxCalculatorGasGas: !ablate::finiteVolume::fluxCalculator::Riemann2Gas
         eosL: *eosAir
         eosR: *eosAir

--- a/tests/integrationTests/inputs/volumeOfFluids/twoGasAdvectingDiscontinuity.yaml
+++ b/tests/integrationTests/inputs/volumeOfFluids/twoGasAdvectingDiscontinuity.yaml
@@ -59,14 +59,15 @@ solver: !ablate::finiteVolume::FiniteVolumeSolver
   id: SOD Problem
   processes:
     - !ablate::finiteVolume::processes::TwoPhaseEulerAdvection
-      eosGas: !ablate::eos::PerfectGas &eosArgon
-        parameters: # argon
-          gamma: 1.66
-          Rgas: 208.13
-      eosLiquid: !ablate::eos::PerfectGas &eosAir
-        parameters: # air
-          gamma: 1.4
-          Rgas: 287.0
+      eos: !ablate::eos::TwoPhase
+        eos1: !ablate::eos::PerfectGas &eosArgon
+          parameters: # argon
+            gamma: 1.66
+            Rgas: 208.13
+        eos2: !ablate::eos::PerfectGas &eosAir
+          parameters: # air
+            gamma: 1.4
+            Rgas: 287.0
       fluxCalculatorGasGas: !ablate::finiteVolume::fluxCalculator::Riemann2Gas
         eosL: *eosArgon
         eosR: *eosArgon

--- a/tests/integrationTests/inputs/volumeOfFluids/twoPhaseCouetteFlow.yaml
+++ b/tests/integrationTests/inputs/volumeOfFluids/twoPhaseCouetteFlow.yaml
@@ -64,15 +64,16 @@ solver: !ablate::finiteVolume::FiniteVolumeSolver
           k: 2.0 #0.598     # W/(mK)
           mu: 4.0 #0.001     # kg/(ms)
     - !ablate::finiteVolume::processes::TwoPhaseEulerAdvection
-      eosGas: !ablate::eos::PerfectGas &eosAir
-        parameters: # air
-          gamma: 1.4
-          Rgas: 287.0
-      eosLiquid: !ablate::eos::StiffenedGas &eosWater
-        parameters: # water
-          gamma: 1.932
-          Cp: 8095.08
-          p0: 1164500000.0
+      eos: !ablate::eos::TwoPhase
+        eos1: !ablate::eos::PerfectGas &eosAir
+          parameters: # air
+            gamma: 1.4
+            Rgas: 287.0
+        eos2: !ablate::eos::StiffenedGas &eosWater
+          parameters: # water
+            gamma: 1.932
+            Cp: 8095.08
+            p0: 1164500000.0
       fluxCalculatorGasGas: !ablate::finiteVolume::fluxCalculator::RiemannStiff
         eosL: *eosAir
         eosR: *eosAir

--- a/tests/integrationTests/inputs/volumeOfFluids/waterGravity.yaml
+++ b/tests/integrationTests/inputs/volumeOfFluids/waterGravity.yaml
@@ -57,15 +57,16 @@ solvers:
       name: interiorCells
     processes:
       - !ablate::finiteVolume::processes::TwoPhaseEulerAdvection
-        eosGas: !ablate::eos::PerfectGas &eosAir
-          parameters: # air
-            gamma: 1.4
-            Rgas: 287.0
-        eosLiquid: !ablate::eos::StiffenedGas &eosWater
-          parameters: # water
-            gamma: 1.932
-            Cp: 8095.08
-            p0: 1164500000.0
+        eos: !ablate::eos::TwoPhase
+          eos1: !ablate::eos::PerfectGas &eosAir
+            parameters: # air
+              gamma: 1.4
+              Rgas: 287.0
+          eos2: !ablate::eos::StiffenedGas &eosWater
+            parameters: # water
+              gamma: 1.932
+              Cp: 8095.08
+              p0: 1164500000.0
         fluxCalculatorGasGas: !ablate::finiteVolume::fluxCalculator::RiemannStiff
           eosL: *eosAir
           eosR: *eosAir

--- a/tests/unitTests/eos/twoPhaseTests.cpp
+++ b/tests/unitTests/eos/twoPhaseTests.cpp
@@ -109,16 +109,55 @@ TEST_P(TPThermodynamicPropertyTestFixture, ShouldComputeProperty) {
 INSTANTIATE_TEST_SUITE_P(
     StiffenedGasEOSTests, TPThermodynamicPropertyTestFixture,
     testing::Values(
-        (TPTestParameters){
+        (TPTestParameters){ // all first gas
+           .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
+           .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
+           .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Temperature,
+           .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                      ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                      ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+           .conservedValues = {1.1614401858304297, 1.1614401858304297 * (215250.0 + 700.0), 1.1614401858304297 * 10, 1.1614401858304297 * -20, 1.1614401858304297 * 30, 1.1614401858304297, 1.0},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
+           .expectedValue = {300.0}},
+        (TPTestParameters){ // all second gas
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
-            .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "3.2"}, {"Rgas", "100.2"}})),
+            .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
+            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Temperature,
+            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+            .conservedValues = {3.132832080200501, 3.132832080200501*(74232.5581395349 + 700.0) , 3.132832080200501 * 10, 3.132832080200501 * -20, 3.132832080200501 * 30, 0.0, 0.0},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
+            .expectedValue = {300.0}},
+        (TPTestParameters){ // mix
+            .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
+            .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
             .thermodynamicProperty = ablate::eos::ThermodynamicProperty::InternalSensibleEnergy,
             .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                        ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
-            .conservedValues = {998.7, 998.7 * 2.5E6, 998.7 * 10, 998.7 * -20, 998.7 * 30, 998.7, 1.0},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
-            .expectedValue = {2499300.0}},
-        (TPTestParameters){
+            .conservedValues = {2.3442753224524724, 2.3442753224524724 * (102178.6483126649 + 700.0), 2.3442753224524724 * 10, 2.3442753224524724 * -20, 2.3442753224524724 * 30, 0.4645760743321719, 0.4},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
+            .expectedValue = {102178.6483126649}},
+
+        (TPTestParameters){ // all air
+            .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
+            .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
+            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::SpeedOfSound,
+            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+            .conservedValues = {1.1614401858304297, 1.1614401858304297 * (215250.0 + 700), 1.1614401858304297 * 10, 1.1614401858304297 * -20, 1.1614401858304297 * 30, 1.1614401858304297, 1.0},
+            .expectedValue = {347.18870949384285}},
+        (TPTestParameters){ // all water
+            .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
+            .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
+            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::SpeedOfSound,
+            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+            .conservedValues = {994.0897497618486, 994.0897497618486 * (2428423.405461103 + 700), 994.0897497618486 * 10, 994.0897497618486 * -20, 994.0897497618486 * 30, 0.0, 0.0},
+            .expectedValue = {1504.4548407978223}},
+        (TPTestParameters){ // mix
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
@@ -128,7 +167,30 @@ INSTANTIATE_TEST_SUITE_P(
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
             .conservedValues = {497.6255949738395, 497.6255949738395 * (2425840.672019258 + 700), 497.6255949738395 * 10, 497.6255949738395 * -20, 497.6255949738395 * 30, 0.5807200929152149, 0.5},
             .expectedValue = {20.04845783548275}},
-        (TPTestParameters){
+
+        (TPTestParameters){ // all first liquid
+            .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
+            .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
+            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Pressure,
+            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+            .conservedValues = {768.3978307143822, 768.3978307143822 * (1392890.3090808005 + 700), 768.3978307143822 * 10, 768.3978307143822 * -20, 768.3978307143822 * 30, 768.3978307143822, 1.0},
+            .expectedValue = {100000.00000023842}},
+        (TPTestParameters){ // all second liquid
+            .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
+            .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
+            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Pressure,
+            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+            .conservedValues = {994.0897497618486, 994.0897497618486 * (2428423.405461103 + 700), 994.0897497618486 * 10, 994.0897497618486 * -20, 994.0897497618486 * 30, 0.0, 0.0},
+            .expectedValue = {100000.0}},
+        (TPTestParameters){ // mix
             .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
@@ -139,6 +201,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
             .conservedValues = {836.105406428622, 836.105406428622 * (1762250.2589397137 + 700), 836.105406428622 * 10, 836.105406428622 * -20, 836.105406428622 * 30, 537.8784815000674, 0.7},
             .expectedValue = {100000.00000023842}},
+
         (TPTestParameters){
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{

--- a/tests/unitTests/eos/twoPhaseTests.cpp
+++ b/tests/unitTests/eos/twoPhaseTests.cpp
@@ -109,35 +109,53 @@ TEST_P(TPThermodynamicPropertyTestFixture, ShouldComputeProperty) {
 INSTANTIATE_TEST_SUITE_P(
     StiffenedGasEOSTests, TPThermodynamicPropertyTestFixture,
     testing::Values(
-        (TPTestParameters){ // all first gas
-           .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
-           .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
-           .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Temperature,
-           .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
-                      ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
-                      ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
-           .conservedValues = {1.1614401858304297, 1.1614401858304297 * (215250.0 + 700.0), 1.1614401858304297 * 10, 1.1614401858304297 * -20, 1.1614401858304297 * 30, 1.1614401858304297, 1.0},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
-           .expectedValue = {300.0}},
-        (TPTestParameters){ // all second gas
+        (TPTestParameters){
+            // all first gas
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
             .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
             .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Temperature,
             .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                        ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
-            .conservedValues = {3.132832080200501, 3.132832080200501*(74232.5581395349 + 700.0) , 3.132832080200501 * 10, 3.132832080200501 * -20, 3.132832080200501 * 30, 0.0, 0.0},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
+            .conservedValues = {1.1614401858304297,
+                                1.1614401858304297 * (215250.0 + 700.0),
+                                1.1614401858304297 * 10,
+                                1.1614401858304297 * -20,
+                                1.1614401858304297 * 30,
+                                1.1614401858304297,
+                                1.0},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
             .expectedValue = {300.0}},
-        (TPTestParameters){ // mix
+        (TPTestParameters){
+            // all second gas
+            .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
+            .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
+            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Temperature,
+            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+            .conservedValues =
+                {3.132832080200501, 3.132832080200501 * (74232.5581395349 + 700.0), 3.132832080200501 * 10, 3.132832080200501 * -20, 3.132832080200501 * 30, 0.0, 0.0},  // rho, rhoE, rhoU, rhoV, rhoW,
+                                                                                                                                                                         // rhoAlpha, alpha
+            .expectedValue = {300.0}},
+        (TPTestParameters){
+            // mix
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
             .eos2 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.43"}, {"Rgas", "106.4"}})),
             .thermodynamicProperty = ablate::eos::ThermodynamicProperty::InternalSensibleEnergy,
             .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
                        ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
-            .conservedValues = {2.3442753224524724, 2.3442753224524724 * (102178.6483126649 + 700.0), 2.3442753224524724 * 10, 2.3442753224524724 * -20, 2.3442753224524724 * 30, 0.4645760743321719, 0.4},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
+            .conservedValues = {2.3442753224524724,
+                                2.3442753224524724 * (102178.6483126649 + 700.0),
+                                2.3442753224524724 * 10,
+                                2.3442753224524724 * -20,
+                                2.3442753224524724 * 30,
+                                0.4645760743321719,
+                                0.4},  // rho, rhoE, rhoU, rhoV, rhoW, rhoAlpha, alpha
             .expectedValue = {102178.6483126649}},
 
-        (TPTestParameters){ // all air
+        (TPTestParameters){
+            // all air
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
@@ -147,7 +165,8 @@ INSTANTIATE_TEST_SUITE_P(
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
             .conservedValues = {1.1614401858304297, 1.1614401858304297 * (215250.0 + 700), 1.1614401858304297 * 10, 1.1614401858304297 * -20, 1.1614401858304297 * 30, 1.1614401858304297, 1.0},
             .expectedValue = {347.18870949384285}},
-        (TPTestParameters){ // all water
+        (TPTestParameters){
+            // all water
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
@@ -157,7 +176,8 @@ INSTANTIATE_TEST_SUITE_P(
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
             .conservedValues = {994.0897497618486, 994.0897497618486 * (2428423.405461103 + 700), 994.0897497618486 * 10, 994.0897497618486 * -20, 994.0897497618486 * 30, 0.0, 0.0},
             .expectedValue = {1504.4548407978223}},
-        (TPTestParameters){ // mix
+        (TPTestParameters){
+            // mix
             .eos1 = std::make_shared<ablate::eos::PerfectGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{{"gamma", "1.4"}, {"Rgas", "287.0"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
@@ -168,7 +188,8 @@ INSTANTIATE_TEST_SUITE_P(
             .conservedValues = {497.6255949738395, 497.6255949738395 * (2425840.672019258 + 700), 497.6255949738395 * 10, 497.6255949738395 * -20, 497.6255949738395 * 30, 0.5807200929152149, 0.5},
             .expectedValue = {20.04845783548275}},
 
-        (TPTestParameters){ // all first liquid
+        (TPTestParameters){
+            // all first liquid
             .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
@@ -179,18 +200,19 @@ INSTANTIATE_TEST_SUITE_P(
                        ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
             .conservedValues = {768.3978307143822, 768.3978307143822 * (1392890.3090808005 + 700), 768.3978307143822 * 10, 768.3978307143822 * -20, 768.3978307143822 * 30, 768.3978307143822, 1.0},
             .expectedValue = {100000.00000023842}},
-        (TPTestParameters){ // all second liquid
-            .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
-                {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
-            .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
-                {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
-            .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Pressure,
-            .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
-                       ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
-                       ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
-            .conservedValues = {994.0897497618486, 994.0897497618486 * (2428423.405461103 + 700), 994.0897497618486 * 10, 994.0897497618486 * -20, 994.0897497618486 * 30, 0.0, 0.0},
-            .expectedValue = {100000.0}},
-        (TPTestParameters){ // mix
+        (TPTestParameters){// all second liquid
+                           .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                               {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
+                           .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
+                               {"gamma", "1.932"}, {"Cp", "8095.08"}, {"p0", "1.1645E9"}})),
+                           .thermodynamicProperty = ablate::eos::ThermodynamicProperty::Pressure,
+                           .fields = {ablate::domain::Field{.name = "euler", .numberComponents = 5, .offset = 0},
+                                      ablate::domain::Field{.name = "densityvolumeFraction", .numberComponents = 1, .offset = 5},
+                                      ablate::domain::Field{.name = "volumeFraction", .numberComponents = 1, .offset = 6}},
+                           .conservedValues = {994.0897497618486, 994.0897497618486 * (2428423.405461103 + 700), 994.0897497618486 * 10, 994.0897497618486 * -20, 994.0897497618486 * 30, 0.0, 0.0},
+                           .expectedValue = {100000.0}},
+        (TPTestParameters){
+            // mix
             .eos1 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{
                 {"gamma", "2.31015"}, {"Cp", "4643.4015"}, {"p0", "6.0695E8"}})),
             .eos2 = std::make_shared<ablate::eos::StiffenedGas>(std::make_shared<ablate::parameters::MapParameters>(std::map<std::string, std::string>{


### PR DESCRIPTION
Allows twoPhaseAdvection solver use physics time step.  Also fixes typo in eos::TwoPhase.