### PR TITLE
simplifies support for fe petscspace in ablate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.18.4)
 include(config/petscCompilers.cmake)
 
 # Set the project details
-project(ablateLibrary VERSION 0.11.8)
+project(ablateLibrary VERSION 0.11.9)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/domain/fieldDescription.hpp
+++ b/src/domain/fieldDescription.hpp
@@ -44,8 +44,8 @@ struct FieldDescription : public FieldDescriptor, public std::enable_shared_from
     // store any optional tags, there are strings that can be used to describe the field
     const std::vector<std::string> tags;
 
-    FieldDescription(std::string name, std::string prefix, std::vector<std::string> components, FieldLocation location, FieldType type, std::shared_ptr<domain::Region> = {},
-                     std::shared_ptr<parameters::Parameters> = {}, std::vector<std::string> tags = {});
+    FieldDescription(std::string name, const std::string& prefix, const std::vector<std::string>& components, FieldLocation location, FieldType type, std::shared_ptr<domain::Region> = {},
+                     const std::shared_ptr<parameters::Parameters>& = {}, std::vector<std::string> tags = {});
 
     /**
      * Public function that will cause the components to expand or decompress based upon the number of dims
@@ -63,8 +63,11 @@ struct FieldDescription : public FieldDescriptor, public std::enable_shared_from
     virtual PetscObject CreatePetscField(DM dm) const;
 
    private:
+    // keep the original Parameters
+    std::shared_ptr<parameters::Parameters> options;
+
     // Petsc options specific for this field
-    PetscOptions options = nullptr;
+    mutable PetscOptions petscOptions = nullptr;
 };
 
 }  // namespace ablate::domain

--- a/src/finiteElement/lowMachFlowFields.cpp
+++ b/src/finiteElement/lowMachFlowFields.cpp
@@ -1,14 +1,31 @@
 #include "lowMachFlowFields.hpp"
 #include "domain/fieldDescription.hpp"
+#include "parameters/mapParameters.hpp"
 
 ablate::finiteElement::LowMachFlowFields::LowMachFlowFields(std::shared_ptr<domain::Region> region, bool includeSourceTerms) : region(region), includeSourceTerms(includeSourceTerms) {}
 
 std::vector<std::shared_ptr<ablate::domain::FieldDescription>> ablate::finiteElement::LowMachFlowFields::GetFields() {
-    std::vector<std::shared_ptr<ablate::domain::FieldDescription>> flowFields{
-        std::make_shared<domain::FieldDescription>(
-            "velocity", "vel", std::vector<std::string>{"vel" + domain::FieldDescription::DIMENSION}, domain::FieldLocation::SOL, domain::FieldType::FEM, region),
-        std::make_shared<domain::FieldDescription>("pressure", "pres", domain::FieldDescription::ONECOMPONENT, domain::FieldLocation::SOL, domain::FieldType::FEM, region),
-        std::make_shared<domain::FieldDescription>("temperature", "temp", domain::FieldDescription::ONECOMPONENT, domain::FieldLocation::SOL, domain::FieldType::FEM, region)};
+    std::vector<std::shared_ptr<ablate::domain::FieldDescription>> flowFields{std::make_shared<domain::FieldDescription>("velocity",
+                                                                                                                         "vel",
+                                                                                                                         std::vector<std::string>{"vel" + domain::FieldDescription::DIMENSION},
+                                                                                                                         domain::FieldLocation::SOL,
+                                                                                                                         domain::FieldType::FEM,
+                                                                                                                         region,
+                                                                                                                         ablate::parameters::MapParameters::Create({{"petscspace_degree", 2}})),
+                                                                              std::make_shared<domain::FieldDescription>("pressure",
+                                                                                                                         "pres",
+                                                                                                                         domain::FieldDescription::ONECOMPONENT,
+                                                                                                                         domain::FieldLocation::SOL,
+                                                                                                                         domain::FieldType::FEM,
+                                                                                                                         region,
+                                                                                                                         ablate::parameters::MapParameters::Create({{"petscspace_degree", 1}})),
+                                                                              std::make_shared<domain::FieldDescription>("temperature",
+                                                                                                                         "temp",
+                                                                                                                         domain::FieldDescription::ONECOMPONENT,
+                                                                                                                         domain::FieldLocation::SOL,
+                                                                                                                         domain::FieldType::FEM,
+                                                                                                                         region,
+                                                                                                                         ablate::parameters::MapParameters::Create({{"petscspace_degree", 1}}))};
 
     if (includeSourceTerms) {
         flowFields.emplace_back(std::make_shared<domain::FieldDescription>(

--- a/src/parameters/mapParameters.cpp
+++ b/src/parameters/mapParameters.cpp
@@ -19,13 +19,13 @@ std::unordered_set<std::string> ablate::parameters::MapParameters::GetKeys() con
     return keys;
 }
 
-ablate::parameters::MapParameters::MapParameters(std::initializer_list<std::pair<std::string, std::string>> list) {
+ablate::parameters::MapParameters::MapParameters(std::initializer_list<Parameter> list) {
     for (const auto& pair : list) {
-        values[pair.first] = pair.second;
+        values[pair.key] = pair.value;
     }
 }
 
-std::shared_ptr<ablate::parameters::MapParameters> ablate::parameters::MapParameters::Create(std::initializer_list<std::pair<std::string, std::string>> values) {
+std::shared_ptr<ablate::parameters::MapParameters> ablate::parameters::MapParameters::Create(std::initializer_list<Parameter> values) {
     return std::make_shared<ablate::parameters::MapParameters>(values);
 }
 

--- a/src/parameters/mapParameters.hpp
+++ b/src/parameters/mapParameters.hpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include "parameters.hpp"
 
 namespace ablate::parameters {
@@ -13,15 +14,62 @@ class MapParameters : public Parameters {
     std::map<std::string, std::string> values;
 
    public:
-    MapParameters(std::initializer_list<std::pair<std::string, std::string>>);
-    MapParameters(std::map<std::string, std::string> values = {});
-    std::optional<std::string> GetString(std::string paramName) const override;
-    std::unordered_set<std::string> GetKeys() const override;
+    /**
+     * Helper class to simplify MapParameters initializer_list
+     */
+    struct Parameter {
+        template <typename T>
+        Parameter(std::string_view key, T value) : key{key} {
+            // convert to string
+            std::stringstream ss;
+            ss << value;
+            ss >> this->value;
+        }
 
-    const std::map<std::string, std::string>& GetMap() const { return values; }
+        std::string key;
+        std::string value;
+    };
 
-    static std::shared_ptr<MapParameters> Create(std::initializer_list<std::pair<std::string, std::string>>);
+    /**
+     * Takes a list of parameters
+     */
+    MapParameters(std::initializer_list<Parameter>);
 
+    /*
+     * Take a map directly
+     */
+    explicit MapParameters(std::map<std::string, std::string> values = {});
+
+    /**
+     * Gets string version of parameter
+     * @param paramName
+     * @return
+     */
+    [[nodiscard]] std::optional<std::string> GetString(std::string paramName) const override;
+
+    /**
+     * List all keys in the domain
+     * @return
+     */
+    [[nodiscard]] std::unordered_set<std::string> GetKeys() const override;
+
+    /**
+     * Provides raw access to the map
+     * @return
+     */
+    [[nodiscard]] const std::map<std::string, std::string>& GetMap() const { return values; }
+
+    /**
+     * static helper function to create a new MapParameters shared pointer from a list of parameters
+     * ablate::parameters::MapParameters::Create({{"item1", "value1"}, {"item2", "value2"}, {"item3", 234}});
+     * @return
+     */
+    static std::shared_ptr<MapParameters> Create(std::initializer_list<Parameter>);
+
+    /**
+     * static helper function to create a new MapParameters shared pointer from a map of <string, string>
+     * @return
+     */
     static std::shared_ptr<MapParameters> Create(const std::map<std::string, std::string>& values);
 };
 }  // namespace ablate::parameters

--- a/src/utilities/petscUtilities.cpp
+++ b/src/utilities/petscUtilities.cpp
@@ -8,23 +8,33 @@ void ablate::utilities::PetscUtilities::Initialize(const char help[]) {
     ablate::environment::RunEnvironment::RegisterCleanUpFunction("ablate::utilities::PetscUtilities::Initialize", []() { PetscFinalize() >> utilities::PetscUtilities::checkError; });
 }
 
-void ablate::utilities::PetscUtilities::Set(const std::string& prefix, const std::map<std::string, std::string>& options) {
+void ablate::utilities::PetscUtilities::Set(const std::string& prefix, const std::map<std::string, std::string>& options, bool override) {
     // March over and set each option in the global petsc database
-    for (auto optionPair : options) {
+    for (const auto& optionPair : options) {
         std::string optionName = "-" + prefix + "" + optionPair.first;
-        PetscOptionsSetValue(NULL, optionName.c_str(), optionPair.second.empty() ? NULL : optionPair.second.c_str()) >> utilities::PetscUtilities::checkError;
+
+        // If not override, check for use first
+        if (!override) {
+            PetscBool exists;
+            PetscOptionsHasName(nullptr, nullptr, optionName.c_str(), &exists) >> utilities::PetscUtilities::checkError;
+            if (exists) {
+                continue;
+            }
+        }
+
+        PetscOptionsSetValue(nullptr, optionName.c_str(), optionPair.second.empty() ? nullptr : optionPair.second.c_str()) >> utilities::PetscUtilities::checkError;
     }
 }
 
 void ablate::utilities::PetscUtilities::Set(const std::map<std::string, std::string>& options) {
-    const std::string noPrefix = "";
+    const std::string noPrefix;
     Set(noPrefix, options);
 }
 
 void ablate::utilities::PetscUtilities::Set(PetscOptions petscOptions, const std::map<std::string, std::string>& options) {
-    for (auto optionPair : options) {
+    for (const auto& optionPair : options) {
         std::string optionName = "-" + optionPair.first;
-        PetscOptionsSetValue(petscOptions, optionName.c_str(), optionPair.second.empty() ? NULL : optionPair.second.c_str()) >> utilities::PetscUtilities::checkError;
+        PetscOptionsSetValue(petscOptions, optionName.c_str(), optionPair.second.empty() ? nullptr : optionPair.second.c_str()) >> utilities::PetscUtilities::checkError;
     }
 }
 

--- a/src/utilities/petscUtilities.hpp
+++ b/src/utilities/petscUtilities.hpp
@@ -49,8 +49,9 @@ class PetscUtilities {
      * Support for setting global petsc options with a prefix and options map
      * @param prefix
      * @param options
+     * @param override force override existing options if present (default true)
      */
-    static void Set(const std::string& prefix, const std::map<std::string, std::string>& options);
+    static void Set(const std::string& prefix, const std::map<std::string, std::string>& options, bool override = true);
 
     /**
      * Support for setting global petsc options with a msp

--- a/tests/integrationTests/inputs/feFlow/incompressibleFlow.yaml
+++ b/tests/integrationTests/inputs/feFlow/incompressibleFlow.yaml
@@ -6,12 +6,6 @@ environment:
   tagDirectory: false
 arguments:
   dm_plex_separate_marker: ""
-  # set the velocity petscspace degree, this is the element order
-  velocity_petscspace_degree: 2
-  # set the pressure petscspace degree, this is the element order
-  pressure_petscspace_degree: 1
-  # set the temperature petscspace degree, this is the element order
-  temperature_petscspace_degree: 1
 
 # set up the time stepper responsible for marching in time
 timestepper:
@@ -50,16 +44,22 @@ timestepper:
         prefix: velocity
         components: ["vel0", "vel1"]
         type: FE
+        options:
+          petscspace_degree: 2
       # define the pressure field using the FE solver
       - !ablate::domain::FieldDescription
         name: pressure
         prefix: pressure
         type: FE
+        options:
+          petscspace_degree: 1
       # define the temperature field using the FE solver
       - !ablate::domain::FieldDescription
         name: temperature
         prefix: temperature
         type: FE
+        options:
+          petscspace_degree: 2
 
   # set the initial conditions of the flow field.  Tag each field function so that they can be reused for the exact solution
   initialization:

--- a/tests/integrationTests/inputs/feFlow/incompressibleFlowIntervalRestart.yaml
+++ b/tests/integrationTests/inputs/feFlow/incompressibleFlowIntervalRestart.yaml
@@ -5,9 +5,6 @@ environment:
   tagDirectory: true
 arguments:
   dm_plex_separate_marker: ""
-  vel_petscspace_degree: 2
-  pres_petscspace_degree: 1
-  temp_petscspace_degree: 1
 timestepper:
   name: theMainTimeStepper
   io:

--- a/tests/integrationTests/inputs/feFlow/incompressibleFlowRestart.yaml
+++ b/tests/integrationTests/inputs/feFlow/incompressibleFlowRestart.yaml
@@ -5,9 +5,6 @@ environment:
   tagDirectory: true
 arguments:
   dm_plex_separate_marker: ""
-  vel_petscspace_degree: 2
-  pres_petscspace_degree: 1
-  temp_petscspace_degree: 1
 timestepper:
   name: theMainTimeStepper
   io:

--- a/tests/unitTests/finiteVolume/compressibleFlowEvDiffusionTests.cpp
+++ b/tests/unitTests/finiteVolume/compressibleFlowEvDiffusionTests.cpp
@@ -135,7 +135,7 @@ TEST_P(CompressibleFlowEvDiffusionTestFixture, ShouldConvergeToExactSolution) {
 
             // create a time stepper
             auto timeStepper = ablate::solver::TimeStepper(mesh,
-                                                           ablate::parameters::MapParameters::Create({{"ts_dt", "5.e-01"}, {"ts_type", "rk"}, {"ts_max_time", "15.0"}, {"ts_adapt_type", "none"}}),
+                                                           ablate::parameters::MapParameters::Create({{"ts_dt", 5.e-01}, {"ts_type", "rk"}, {"ts_max_time", 15.0}, {"ts_adapt_type", "none"}}),
                                                            {},
                                                            initialization,
                                                            std::vector<std::shared_ptr<mathFunctions::FieldFunction>>{eulerExactField, evExactField});

--- a/tests/unitTests/finiteVolume/compressibleFlowSpeciesDiffusionTests.cpp
+++ b/tests/unitTests/finiteVolume/compressibleFlowSpeciesDiffusionTests.cpp
@@ -155,7 +155,7 @@ TEST_P(CompressibleFlowSpeciesDiffusionTestFixture, ShouldConvergeToExactSolutio
             // create a time stepper
             auto timeStepper = ablate::solver::TimeStepper("timeStepper",
                                                            mesh,
-                                                           ablate::parameters::MapParameters::Create({{"ts_dt", "5.e-01"}, {"ts_type", "rk"}, {"ts_max_time", "15.0"}, {"ts_adapt_type", "none"}}),
+                                                           ablate::parameters::MapParameters::Create({{"ts_dt", 5.e-01}, {"ts_type", "rk"}, {"ts_max_time", 15.0}, {"ts_adapt_type", "none"}}),
                                                            nullptr,
                                                            exactSolutions,
                                                            exactSolutions);

--- a/tests/unitTests/mathFunctions/formulaTests.cpp
+++ b/tests/unitTests/mathFunctions/formulaTests.cpp
@@ -83,10 +83,10 @@ INSTANTIATE_TEST_SUITE_P(FormulaTests, FormulaScalarFixture,
                                          (FormulaScalarParameters){.formula = "t*vel + test", .nested = {{"vel", "3.0*y"}, {"test", "z"}}, .constants = {}, .expectedResult = 27},
                                          (FormulaScalarParameters){.formula = "t*vel + test + CC/AA",
                                                                    .nested = {{"vel", "3.0*y"}, {"test", "z"}},
-                                                                   .constants = ablate::parameters::MapParameters::Create({{"CC", "3"}, {"AA", "1.5"}}),
+                                                                   .constants = ablate::parameters::MapParameters::Create({{"CC", 3}, {"AA", 1.5}}),
                                                                    .expectedResult = 29},
                                          (FormulaScalarParameters){
-                                             .formula = "t*CC/AA", .nested = {}, .constants = ablate::parameters::MapParameters::Create({{"CC", "3"}, {"AA", "1.5"}}), .expectedResult = 8}));
+                                             .formula = "t*CC/AA", .nested = {}, .constants = ablate::parameters::MapParameters::Create({{"CC", 3}, {"AA", 1.5}}), .expectedResult = 8}));
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct FormulaTestsVectorParameters {
@@ -157,12 +157,10 @@ INSTANTIATE_TEST_SUITE_P(
                     (FormulaTestsVectorParameters){.formula = "t*vel + test", .nested = {{"vel", "3.0*y"}, {"test", "z"}}, .constants = {}, .expectedResult = {27}},
                     (FormulaTestsVectorParameters){.formula = "v*x, v*z + y", .nested = {{"v", "3.0*y"}}, .constants = {}, .expectedResult = {6, 20}},
                     (FormulaTestsVectorParameters){.formula = "0, i*y, t/i", .nested = {{"i", "10.0"}}, .constants = {}, .expectedResult = {0, 20, 0.4}},
-                    (FormulaTestsVectorParameters){.formula = "0+CC, i*y+CC, t/i+AA",
-                                                   .nested = {{"i", "10.0"}},
-                                                   .constants = ablate::parameters::MapParameters::Create({{"CC", "3"}, {"AA", "1.5"}}),
-                                                   .expectedResult = {3, 23, 1.9}},
                     (FormulaTestsVectorParameters){
-                        .formula = "0+CC, y+CC, t+AA", .nested = {}, .constants = ablate::parameters::MapParameters::Create({{"CC", "3"}, {"AA", "1.5"}}), .expectedResult = {3, 5, 5.5}}));
+                        .formula = "0+CC, i*y+CC, t/i+AA", .nested = {{"i", "10.0"}}, .constants = ablate::parameters::MapParameters::Create({{"CC", 3}, {"AA", 1.5}}), .expectedResult = {3, 23, 1.9}},
+                    (FormulaTestsVectorParameters){
+                        .formula = "0+CC, y+CC, t+AA", .nested = {}, .constants = ablate::parameters::MapParameters::Create({{"CC", 3}, {"AA", 1.5}}), .expectedResult = {3, 5, 5.5}}));
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 TEST(FormulaTests, ShouldProduceDeterministicPsueduRandomNumber) {

--- a/tests/unitTests/mathFunctions/parsedSeriesTests.cpp
+++ b/tests/unitTests/mathFunctions/parsedSeriesTests.cpp
@@ -69,7 +69,7 @@ INSTANTIATE_TEST_SUITE_P(ParsedSeriesTests, ParsedSeriesTestsScalarFixture,
                                          (ParsedSeriesTestsScalarParameters){.formula = "i*x + y", .lowerBound = 0, .upperBound = 0, .constants = {}, .expectedResult = 2},
                                          (ParsedSeriesTestsScalarParameters){.formula = "t*i*i", .lowerBound = 0, .upperBound = 10, .constants = {}, .expectedResult = 1540},
                                          (ParsedSeriesTestsScalarParameters){
-                                             .formula = "t*i*i*a", .lowerBound = 0, .upperBound = 10, .constants = ablate::parameters::MapParameters::Create({{"a", "0.5"}}), .expectedResult = 770}));
+                                             .formula = "t*i*i*a", .lowerBound = 0, .upperBound = 10, .constants = ablate::parameters::MapParameters::Create({{"a", 0.5}}), .expectedResult = 770}));
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct ParsedSeriesTestsVectorParameters {
@@ -143,7 +143,7 @@ INSTANTIATE_TEST_SUITE_P(ParsedSeriesTests, ParsedSeriesTestsVectorFixture,
                                          (ParsedSeriesTestsVectorParameters){.formula = "b, i*y*a, t*c",
                                                                              .lowerBound = 1,
                                                                              .upperBound = 10,
-                                                                             .constants = ablate::parameters::MapParameters::Create({{"c", "3"}, {"a", "0.5"}, {"b", "1.5"}}),
+                                                                             .constants = ablate::parameters::MapParameters::Create({{"c", 3}, {"a", 0.5}, {"b", 1.5}}),
                                                                              .expectedResult = {15, 55, 120}}));
 
 }  // namespace ablateTesting::mathFunctions

--- a/tests/unitTests/parameters/mapParameterTests.cpp
+++ b/tests/unitTests/parameters/mapParameterTests.cpp
@@ -16,19 +16,21 @@ TEST(MapParametersTests, ShouldCreateFromMap) {
 TEST(MapParametersTests, ShouldCreateFromInitializerList) {
     // arrange
     // act
-    ablate::parameters::MapParameters mapParameters = {{"item1", "value1"}, {"item2", "value2"}};
+    ablate::parameters::MapParameters mapParameters = {{"item1", "value1"}, {"item2", "value2"}, {"item3", 234}};
 
     // assert
     ASSERT_EQ(mapParameters.GetString("item1"), "value1");
     ASSERT_EQ(mapParameters.GetString("item2"), "value2");
+    ASSERT_EQ(mapParameters.GetString("item3"), "234");
 }
 
 TEST(MapParametersTests, ShouldSupportCreateFunction) {
     // arrange
     // act
-    auto mapParameters = ablate::parameters::MapParameters::Create({{"item1", "value1"}, {"item2", "value2"}});
+    auto mapParameters = ablate::parameters::MapParameters::Create({{"item1", "value1"}, {"item2", "value2"}, {"item3", 234}});
 
     // assert
     ASSERT_EQ(mapParameters->GetString("item1"), "value1");
     ASSERT_EQ(mapParameters->GetString("item2"), "value2");
+    ASSERT_EQ(mapParameters->GetString("item3"), "234");
 }

--- a/tests/unitTests/radiation/radiationTests.cpp
+++ b/tests/unitTests/radiation/radiationTests.cpp
@@ -188,7 +188,7 @@ TEST_P(RadiationTestFixture, ShouldComputeCorrectSourceTerm) {
         auto initialConditionEuler = std::make_shared<ablate::mathFunctions::FieldFunction>("euler", std::make_shared<ablate::mathFunctions::ConstantValue>(0.0));
 
         // create a time stepper
-        auto timeStepper = ablate::solver::TimeStepper("timeStepper", domain, ablate::parameters::MapParameters::Create({{"ts_max_steps", "0"}}), {}, {initialConditionEuler});
+        auto timeStepper = ablate::solver::TimeStepper("timeStepper", domain, ablate::parameters::MapParameters::Create({{"ts_max_steps", 0}}), {}, {initialConditionEuler});
 
         // Create an instance of radiation
         auto radiationPropertiesModel = std::make_shared<ablate::eos::radiationProperties::Constant>(1.0);


### PR DESCRIPTION
In yaml you can specify the petscspace as 
```yaml
      # define the pressure field using the FE solver
      - !ablate::domain::FieldDescription
        name: pressure
        prefix: pressure
        type: FE
        options:
          petscspace_degree: 1
```

or in code
```c++
std::make_shared<domain::FieldDescription>("velocity",
  "vel",
  std::vector<std::string>{"vel" + domain::FieldDescription::DIMENSION},
  domain::FieldLocation::SOL,
  domain::FieldType::FEM,
  region,
  ablate::parameters::MapParameters::Create({{"petscspace_degree", 2}}))
```
