### PR TITLE
Added new way to specify compiler options for CCR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ target_link_libraries(ablateLibrary
         Threads::Threads
         nlohmann_json::nlohmann_json
         ${HDF5_LIBRARIES}
-        BLAS::BLAS
         PRIVATE
         chrestCompilerFlags)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ include(config/findChrestCompilerFlags.cmake)
 include(config/findSLEPc.cmake)
 include(config/printVersion.cmake)
 find_package(HDF5 REQUIRED)
-find_package(BLAS)
 
 # specify in the required libaries
 target_link_libraries(ablateLibrary
@@ -67,6 +66,15 @@ target_link_libraries(ablateLibrary
         BLAS::BLAS
         PRIVATE
         chrestCompilerFlags)
+
+# depending upon the build, we may need to add blas
+find_package(BLAS)
+if (BLAS_FOUND)
+    target_link_libraries(ablateLibrary
+            PUBLIC
+            BLAS::BLAS)
+endif ()
+
 
 # Set the ablate library requirements
 set_property(TARGET ablateLibrary PROPERTY CXX_EXTENSIONS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ include(config/findChrestCompilerFlags.cmake)
 include(config/findSLEPc.cmake)
 include(config/printVersion.cmake)
 find_package(HDF5 REQUIRED)
+find_package(BLAS)
 
 # specify in the required libaries
 target_link_libraries(ablateLibrary
@@ -63,6 +64,7 @@ target_link_libraries(ablateLibrary
         Threads::Threads
         nlohmann_json::nlohmann_json
         ${HDF5_LIBRARIES}
+        BLAS::BLAS
         PRIVATE
         chrestCompilerFlags)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ include(config/findChrestCompilerFlags.cmake)
 include(config/findSLEPc.cmake)
 include(config/printVersion.cmake)
 find_package(HDF5 REQUIRED)
-set(BLA_STATIC ON)
 find_package(BLAS REQUIRED)
 
 # specify in the required libaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ include(config/findSLEPc.cmake)
 include(config/printVersion.cmake)
 find_package(HDF5 REQUIRED)
 set(BLA_STATIC ON)
-find_package(BLAS)
+find_package(BLAS REQUIRED)
 
 # specify in the required libaries
 target_link_libraries(ablateLibrary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ include(config/findChrestCompilerFlags.cmake)
 include(config/findSLEPc.cmake)
 include(config/printVersion.cmake)
 find_package(HDF5 REQUIRED)
+set(BLA_STATIC ON)
 find_package(BLAS)
 
 # specify in the required libaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ include(config/findChrestCompilerFlags.cmake)
 include(config/findSLEPc.cmake)
 include(config/printVersion.cmake)
 find_package(HDF5 REQUIRED)
-find_package(BLAS REQUIRED)
+find_package(BLAS)
 
 # specify in the required libaries
 target_link_libraries(ablateLibrary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.18.4)
 include(config/petscCompilers.cmake)
 
 # Set the project details
-project(ablateLibrary VERSION 0.12.15)
+project(ablateLibrary VERSION 0.12.16)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/config/petscCompilers.cmake
+++ b/config/petscCompilers.cmake
@@ -35,6 +35,12 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 
     pkg_get_variable(PETSC_CXX_FLAGS PETSc cxxflags_extra)
     configure_flags("${PETSC_CXX_FLAGS}" PETSC_FLAGS_OUT)
+
+    # allow adding custom CXX_ADDITIONAL_FLAGS
+    if (DEFINED ENV{CXX_ADDITIONAL_FLAGS})
+        string(APPEND PETSC_FLAGS_OUT " " $ENV{CXX_ADDITIONAL_FLAGS})
+    endif ()
+
     set(CMAKE_CXX_FLAGS_INIT ${PETSC_FLAGS_OUT})
 
     message(STATUS "Using found PETSc c++ Compiler/Flags: ${PETSC_CXX_COMPILER} ${PETSC_FLAGS_OUT}\n")

--- a/config/systemHacks.cmake
+++ b/config/systemHacks.cmake
@@ -13,11 +13,11 @@ if ("${APPLE}" AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang"))
 endif ()
 
 ## update the install rpaths
-#if (APPLE)
-#    set(CMAKE_MACOSX_RPATH 1)
-#    set_target_properties(ablate PROPERTIES
-#            INSTALL_RPATH "@loader_path;@loader_path/...;@executable_path;@executable_path/../${CMAKE_INSTALL_LIBDIR};@rpath")
-#elseif (UNIX)
-#    set_target_properties(ablate PROPERTIES
-#            INSTALL_RPATH "$ORIGIN:$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/...")
-#endif ()
+if (APPLE)
+    set(CMAKE_MACOSX_RPATH 1)
+    set_target_properties(ablate PROPERTIES
+            INSTALL_RPATH "@loader_path;@loader_path/...;@executable_path;@executable_path/../${CMAKE_INSTALL_LIBDIR};@rpath")
+elseif (UNIX)
+    set_target_properties(ablate PROPERTIES
+            INSTALL_RPATH "$ORIGIN:$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/...")
+endif ()

--- a/config/systemHacks.cmake
+++ b/config/systemHacks.cmake
@@ -13,11 +13,11 @@ if ("${APPLE}" AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang"))
 endif ()
 
 ## update the install rpaths
-if (APPLE)
-    set(CMAKE_MACOSX_RPATH 1)
-    set_target_properties(ablate PROPERTIES
-            INSTALL_RPATH "@loader_path;@loader_path/...;@executable_path;@executable_path/../${CMAKE_INSTALL_LIBDIR};@rpath")
-elseif (UNIX)
-    set_target_properties(ablate PROPERTIES
-            INSTALL_RPATH "$ORIGIN:$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/...")
-endif ()
+#if (APPLE)
+#    set(CMAKE_MACOSX_RPATH 1)
+#    set_target_properties(ablate PROPERTIES
+#            INSTALL_RPATH "@loader_path;@loader_path/...;@executable_path;@executable_path/../${CMAKE_INSTALL_LIBDIR};@rpath")
+#elseif (UNIX)
+#    set_target_properties(ablate PROPERTIES
+#            INSTALL_RPATH "$ORIGIN:$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/...")
+#endif ()


### PR DESCRIPTION
The ENV variable CXX_ADDITIONAL_FLAGS is added to options found in PETSc