### PR TITLE
Mcgurn/asan test fix

### DIFF
--- a/.github/workflows/RegressionTestWorkflow.yml
+++ b/.github/workflows/RegressionTestWorkflow.yml
@@ -19,7 +19,6 @@ jobs:
         petscConfig: [ arch-ablate-opt ]
         tensorFlowConfig: [ "", "enabled_tf" ]
     runs-on: ${{ matrix.arch.runson }}
-    timeout-minutes: 240
 
     steps:
       - name: Set up Docker Buildx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.18.4)
 include(config/petscCompilers.cmake)
 
 # Set the project details
-project(ablateLibrary VERSION 0.12.18)
+project(ablateLibrary VERSION 0.12.19)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/tests/integrationTests/main.cpp
+++ b/tests/integrationTests/main.cpp
@@ -11,21 +11,26 @@
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
+    // store the yaml parser and test to prevent premature deletion
+    std::vector<std::shared_ptr<cppParser::YamlParser>> parsers;
+    std::vector<std::shared_ptr<IntegrationTestFixture>> integrationTests;
+
     // register of all tests
     // list all directories input path
     for (const auto& entry : std::filesystem::recursive_directory_iterator("inputs")) {
         // check to see if it is an input file
         if (entry.path().extension() == ".yaml") {
             // Load in the input file
-            std::shared_ptr<cppParser::YamlParser> parser = std::make_shared<cppParser::YamlParser>(entry.path());
+            auto parser = std::make_shared<cppParser::YamlParser>(entry.path());
+            parsers.push_back(parser);
 
             // set up the monitor
             if (parser->Contains("test")) {
                 auto integrationTest = parser->GetByName<IntegrationTestFixture>("test");
-
+                integrationTests.push_back(integrationTest);
                 // Register the test
                 integrationTest->RegisterTest(entry);
-            } else if (parser->Contains("tests")) {
+            } /*else if (parser->Contains("tests")) {
                 auto integrationTests = parser->GetByName<std::vector<IntegrationTestFixture>>("tests");
 
                 // Register the test
@@ -34,7 +39,7 @@ int main(int argc, char** argv) {
                 }
             } else if (!parser->GetByName<bool>("testingIgnore", false)) {
                 throw std::invalid_argument("An input file " + entry.path().string() + " in integration tests does not contain test parameters.");
-            }
+            } */
         }
     }
 

--- a/tests/integrationTests/main.cpp
+++ b/tests/integrationTests/main.cpp
@@ -11,26 +11,21 @@
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
 
-    // store the yaml parser and test to prevent premature deletion
-    std::vector<std::shared_ptr<cppParser::YamlParser>> parsers;
-    std::vector<std::shared_ptr<IntegrationTestFixture>> integrationTests;
-
     // register of all tests
     // list all directories input path
     for (const auto& entry : std::filesystem::recursive_directory_iterator("inputs")) {
         // check to see if it is an input file
         if (entry.path().extension() == ".yaml") {
             // Load in the input file
-            auto parser = std::make_shared<cppParser::YamlParser>(entry.path());
-            parsers.push_back(parser);
+            std::shared_ptr<cppParser::YamlParser> parser = std::make_shared<cppParser::YamlParser>(entry.path());
 
             // set up the monitor
             if (parser->Contains("test")) {
                 auto integrationTest = parser->GetByName<IntegrationTestFixture>("test");
-                integrationTests.push_back(integrationTest);
+
                 // Register the test
                 integrationTest->RegisterTest(entry);
-            } /*else if (parser->Contains("tests")) {
+            } else if (parser->Contains("tests")) {
                 auto integrationTests = parser->GetByName<std::vector<IntegrationTestFixture>>("tests");
 
                 // Register the test
@@ -39,7 +34,7 @@ int main(int argc, char** argv) {
                 }
             } else if (!parser->GetByName<bool>("testingIgnore", false)) {
                 throw std::invalid_argument("An input file " + entry.path().string() + " in integration tests does not contain test parameters.");
-            } */
+            }
         }
     }
 

--- a/tests/testingResources/integrationRestartTest.cpp
+++ b/tests/testingResources/integrationRestartTest.cpp
@@ -14,7 +14,7 @@ IntegrationRestartTest::IntegrationRestartTest(std::shared_ptr<testingResources:
 
 void IntegrationRestartTest::RegisterTest(const std::filesystem::path& inputPath) {
     // make a raw pointer copy of the integration test
-    auto integrationTestCopy = new IntegrationRestartTest(mpiTestParameter, restartInputFile, restartOverrides);
+    /*auto integrationTestCopy = new IntegrationRestartTest(mpiTestParameter, restartInputFile, restartOverrides);
     integrationTestCopy->inputFilePath = inputPath;
 
     // check to see if it contains a test target
@@ -25,7 +25,7 @@ void IntegrationRestartTest::RegisterTest(const std::filesystem::path& inputPath
                           absolute(inputPath).c_str(),
                           1,
                           // Important to use the fixture type as the return type here.
-                          [=]() -> IntegrationRestartTestFixture* { return integrationTestCopy; });
+                          [=]() -> IntegrationRestartTestFixture* { return integrationTestCopy; });*/
 }
 
 void IntegrationRestartTest::TestBody() {

--- a/tests/testingResources/integrationRestartTest.cpp
+++ b/tests/testingResources/integrationRestartTest.cpp
@@ -13,19 +13,24 @@ IntegrationRestartTest::IntegrationRestartTest(std::shared_ptr<testingResources:
     : IntegrationRestartTestFixture(std::move(mpiTestParameter), std::move(restartInputFile), std::move(restartOverrides)) {}
 
 void IntegrationRestartTest::RegisterTest(const std::filesystem::path& inputPath) {
-    // make a raw pointer copy of the integration test
-    /*auto integrationTestCopy = new IntegrationRestartTest(mpiTestParameter, restartInputFile, restartOverrides);
-    integrationTestCopy->inputFilePath = inputPath;
+    inputFilePath = inputPath;
+
+    // get a copy of this pointer so that this lambda can prevent deletion
+    auto testPointer = shared_from_this();
 
     // check to see if it contains a test target
-    testing::RegisterTest(integrationTestCopy->GetTestSuiteName(std::filesystem::path("inputs"), "IntegrationRestart").c_str(),
-                          integrationTestCopy->GetTestName().c_str(),
+    testing::RegisterTest(GetTestSuiteName(std::filesystem::path("inputs"), "IntegrationRestart").c_str(),
+                          GetTestName().c_str(),
                           nullptr,
                           nullptr,
                           absolute(inputPath).c_str(),
                           1,
                           // Important to use the fixture type as the return type here.
-                          [=]() -> IntegrationRestartTestFixture* { return integrationTestCopy; });*/
+                          [testPointer]() -> IntegrationRestartTestFixture* {
+                              auto newTestPointer = new IntegrationRestartTest(testPointer->mpiTestParameter, testPointer->restartInputFile, testPointer->restartOverrides);
+                              newTestPointer->inputFilePath = testPointer->inputFilePath;
+                              return newTestPointer;
+                          });
 }
 
 void IntegrationRestartTest::TestBody() {

--- a/tests/testingResources/integrationRestartTest.hpp
+++ b/tests/testingResources/integrationRestartTest.hpp
@@ -31,7 +31,7 @@ class IntegrationRestartTestFixture : public IntegrationTestFixture {
 /**
  * Integration restart test holds the actual integration restart test code for IntegrationRestartTestFixture
  */
-class IntegrationRestartTest : public IntegrationRestartTestFixture {
+class IntegrationRestartTest : public IntegrationRestartTestFixture, public std::enable_shared_from_this<IntegrationRestartTest> {
    public:
     explicit IntegrationRestartTest(std::shared_ptr<testingResources::MpiTestParameter> mpiTestParameter, std::string restartInputFile,
                                     std::shared_ptr<ablate::parameters::Parameters> restartOverrides);

--- a/tests/testingResources/integrationTest.cpp
+++ b/tests/testingResources/integrationTest.cpp
@@ -9,7 +9,6 @@ IntegrationTestFixture::IntegrationTestFixture(std::shared_ptr<testingResources:
 IntegrationTest::IntegrationTest(std::shared_ptr<testingResources::MpiTestParameter> mpiTestParameter) : IntegrationTestFixture(std::move(mpiTestParameter)) {}
 
 void IntegrationTest::RegisterTest(const std::filesystem::path& inputPath) {
-    // make a raw pointer copy of the integration test
     inputFilePath = inputPath;
 
     // get a copy of this pointer so that this lambda can prevent deletion
@@ -26,7 +25,8 @@ void IntegrationTest::RegisterTest(const std::filesystem::path& inputPath) {
                           [testPointer]() -> IntegrationTestFixture* {
                               auto newTestPointer = new IntegrationTest(testPointer->mpiTestParameter);
                               newTestPointer->inputFilePath = testPointer->inputFilePath;
-                              return newTestPointer;});
+                              return newTestPointer;
+                          });
 }
 
 void IntegrationTest::TestBody() {

--- a/tests/testingResources/integrationTest.hpp
+++ b/tests/testingResources/integrationTest.hpp
@@ -65,7 +65,7 @@ class IntegrationTestFixture : public testingResources::MpiTestFixture {
 /**
  * The actual class that tests all typical types of integration tests
  */
-class IntegrationTest : public IntegrationTestFixture {
+class IntegrationTest : public IntegrationTestFixture, public std::enable_shared_from_this<IntegrationTest>  {
    public:
     explicit IntegrationTest(std::shared_ptr<testingResources::MpiTestParameter> mpiTestParameter);
 

--- a/tests/testingResources/integrationTest.hpp
+++ b/tests/testingResources/integrationTest.hpp
@@ -65,7 +65,7 @@ class IntegrationTestFixture : public testingResources::MpiTestFixture {
 /**
  * The actual class that tests all typical types of integration tests
  */
-class IntegrationTest : public IntegrationTestFixture, public std::enable_shared_from_this<IntegrationTest>  {
+class IntegrationTest : public IntegrationTestFixture, public std::enable_shared_from_this<IntegrationTest> {
    public:
     explicit IntegrationTest(std::shared_ptr<testingResources::MpiTestParameter> mpiTestParameter);
 

--- a/tests/testingResources/mpiTestFixture.hpp
+++ b/tests/testingResources/mpiTestFixture.hpp
@@ -107,6 +107,10 @@ class MpiTestFixture : public ::testing::Test {
      */
     void SetMpiParameters(MpiTestParameter mpiTestParameterIn) { mpiTestParameter = std::move(mpiTestParameterIn); }
 
+    /**
+     * The executable path to call
+     * @return
+     */
     [[nodiscard]] static std::string ExecutablePath() { return {*argv[0]}; }
 
     /**
@@ -121,7 +125,7 @@ class MpiTestFixture : public ::testing::Test {
      * Build the result directory before the run
      * @return
      */
-    std::filesystem::path BuildResultDirectory() const;
+    [[nodiscard]] std::filesystem::path BuildResultDirectory() const;
 
     /**
      * Determine if we should run mpi code or launch a new processes instead


### PR DESCRIPTION
fixed a bug in the new testing library that resulted in the asan tests failing. 