### PR TITLE
Adding Support for defining different boundary region on outer shell boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.18.4)
 include(config/petscCompilers.cmake)
 
 # Set the project details
-project(ablateLibrary VERSION 0.12.29)
+project(ablateLibrary VERSION 0.12.30)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)

--- a/src/domain/descriptions/axisymmetric.cpp
+++ b/src/domain/descriptions/axisymmetric.cpp
@@ -121,8 +121,8 @@ std::shared_ptr<ablate::domain::Region> ablate::domain::descriptions::Axisymmetr
 
     // compute the outer shell start
     auto outerShellStart = numberCenterVertices + numberVerticesPerShell * (numberShells - 1);
-    //Coordinate used to track the z location
-    auto* coordinate = new PetscReal[]{0.0,0.0,0.0};
+    // Coordinate used to track the z location
+    auto *coordinate = new PetscReal[]{0.0, 0.0, 0.0};
     PetscReal Zavg = 0.0;
     for (const auto &node : face) {
         // check if we are on the outer shell
@@ -144,17 +144,17 @@ std::shared_ptr<ablate::domain::Region> ablate::domain::descriptions::Axisymmetr
         if (nodeSlice != numberSlices) {
             onUpperEndCap = false;
         }
-        axisDescription->SetCoordinate(nodeSlice,coordinate);
+        axisDescription->SetCoordinate(nodeSlice, coordinate);
         Zavg += coordinate[2];
     }
     // determine what region to return
     if (onOuterShell) {
-        if(!boundaryFunction){
+        if (!boundaryFunction) {
             return shellBoundary;
-        }else{
+        } else {
             Zavg /= face.size();
             coordinate[2] = Zavg;
-            auto val = boundaryFunction->Eval(coordinate,3,NAN);
+            auto val = boundaryFunction->Eval(coordinate, 3, NAN);
             return std::make_shared<ablate::domain::Region>("outerShell", int(val));
         }
     } else if (onLowerEndCap) {
@@ -171,4 +171,4 @@ REGISTER(ablate::domain::descriptions::MeshDescription, ablate::domain::descript
          ARG(ablate::domain::descriptions::AxisDescription, "axis", "describes the nodes along the z axis"),
          ARG(ablate::mathFunctions::MathFunction, "radius", "a radius function that describes the radius as a function of z"), ARG(int, "numberWedges", "wedges/pie slices in the circle"),
          ARG(int, "numberShells", "slicing of the cylinder along the radius"),
-         OPT(ablate::mathFunctions::MathFunction, "outerBoundaryFunction", "Function to tag different outer shell boundary regions" ));
+         OPT(ablate::mathFunctions::MathFunction, "outerBoundaryFunction", "Function to tag different outer shell boundary regions"));

--- a/src/domain/descriptions/axisymmetric.cpp
+++ b/src/domain/descriptions/axisymmetric.cpp
@@ -4,7 +4,7 @@
 #include "utilities/vectorUtilities.hpp"
 
 ablate::domain::descriptions::Axisymmetric::Axisymmetric(std::shared_ptr<ablate::domain::descriptions::AxisDescription> axis, std::shared_ptr<ablate::mathFunctions::MathFunction> radiusFunction,
-                                                         PetscInt numberWedges, PetscInt numberShells)
+                                                         PetscInt numberWedges, PetscInt numberShells, std::shared_ptr<ablate::mathFunctions::MathFunction> boundaryFunction)
     : axisDescription(std::move(axis)),
       radiusFunction(std::move(radiusFunction)),
       numberWedges(numberWedges),
@@ -16,7 +16,8 @@ ablate::domain::descriptions::Axisymmetric::Axisymmetric(std::shared_ptr<ablate:
       numberCenterVertices(numberSlices + 1),
       numberCells(numberCellsPerSlice * numberSlices),
       numberVertices(numberVerticesPerShell * numberShells + numberCenterVertices),
-      numberTriPrismCells(numberWedges * numberSlices) {
+      numberTriPrismCells(numberWedges * numberSlices),
+      boundaryFunction(std::move(boundaryFunction)) {
     // make sure there are at least 4 wedges and one slice
     if (numberWedges < 3 || numberSlices < 1 || numberShells < 1) {
         throw std::invalid_argument("Axisymmetric requires at least 3 wedges, 1 slice, and 1 shell.");
@@ -120,7 +121,9 @@ std::shared_ptr<ablate::domain::Region> ablate::domain::descriptions::Axisymmetr
 
     // compute the outer shell start
     auto outerShellStart = numberCenterVertices + numberVerticesPerShell * (numberShells - 1);
-
+    //Coordinate used to track the z location
+    auto* coordinate = new PetscReal[]{0.0,0.0,0.0};
+    PetscReal Zavg = 0.0;
     for (const auto &node : face) {
         // check if we are on the outer shell
         if (node < outerShellStart) {
@@ -141,11 +144,19 @@ std::shared_ptr<ablate::domain::Region> ablate::domain::descriptions::Axisymmetr
         if (nodeSlice != numberSlices) {
             onUpperEndCap = false;
         }
+        axisDescription->SetCoordinate(nodeSlice,coordinate);
+        Zavg += coordinate[2];
     }
-
     // determine what region to return
     if (onOuterShell) {
-        return shellBoundary;
+        if(!boundaryFunction){
+            return shellBoundary;
+        }else{
+            Zavg /= face.size();
+            coordinate[2] = Zavg;
+            auto val = boundaryFunction->Eval(coordinate,3,NAN);
+            return std::make_shared<ablate::domain::Region>("outerShell", int(val));
+        }
     } else if (onLowerEndCap) {
         return lowerCapBoundary;
     } else if (onUpperEndCap) {
@@ -159,4 +170,5 @@ std::shared_ptr<ablate::domain::Region> ablate::domain::descriptions::Axisymmetr
 REGISTER(ablate::domain::descriptions::MeshDescription, ablate::domain::descriptions::Axisymmetric, "The Axisymmetric MeshDescription is used to create an axisymmetric mesh around the z axis",
          ARG(ablate::domain::descriptions::AxisDescription, "axis", "describes the nodes along the z axis"),
          ARG(ablate::mathFunctions::MathFunction, "radius", "a radius function that describes the radius as a function of z"), ARG(int, "numberWedges", "wedges/pie slices in the circle"),
-         ARG(int, "numberShells", "slicing of the cylinder along the radius"));
+         ARG(int, "numberShells", "slicing of the cylinder along the radius"),
+         OPT(ablate::mathFunctions::MathFunction, "outerBoundaryFunction", "Function to tag different outer shell boundary regions" ));

--- a/src/domain/descriptions/axisymmetric.cpp
+++ b/src/domain/descriptions/axisymmetric.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<ablate::domain::Region> ablate::domain::descriptions::Axisymmetr
     // compute the outer shell start
     auto outerShellStart = numberCenterVertices + numberVerticesPerShell * (numberShells - 1);
     // Coordinate used to track the z location
-    auto *coordinate = new PetscReal[]{0.0, 0.0, 0.0};
+    PetscReal coordinate[3] = {0.0, 0.0, 0.0};
     PetscReal Zavg = 0.0;
     for (const auto &node : face) {
         // check if we are on the outer shell

--- a/src/domain/descriptions/axisymmetric.hpp
+++ b/src/domain/descriptions/axisymmetric.hpp
@@ -77,8 +77,8 @@ class Axisymmetric : public ablate::domain::descriptions::MeshDescription {
      * @param numberWedges wedges/pie slices in the circle
      * @param numberShells slicing of the cylinder along the radius
      */
-    Axisymmetric(std::shared_ptr<ablate::domain::descriptions::AxisDescription> axis, std::shared_ptr<ablate::mathFunctions::MathFunction> radiusFunction, PetscInt numberWedges,
-                 PetscInt numberShells, std::shared_ptr<ablate::mathFunctions::MathFunction> boundaryFunction);
+    Axisymmetric(std::shared_ptr<ablate::domain::descriptions::AxisDescription> axis, std::shared_ptr<ablate::mathFunctions::MathFunction> radiusFunction, PetscInt numberWedges, PetscInt numberShells,
+                 std::shared_ptr<ablate::mathFunctions::MathFunction> boundaryFunction);
 
     /**
      * The overall assumed dimension of the mesh

--- a/src/domain/descriptions/axisymmetric.hpp
+++ b/src/domain/descriptions/axisymmetric.hpp
@@ -54,6 +54,9 @@ class Axisymmetric : public ablate::domain::descriptions::MeshDescription {
     //! store the number of tri prism cells to simplify the logic
     const PetscInt numberTriPrismCells;
 
+    //! function used to describe a different boundary regions on the outer shell boundary
+    const std::shared_ptr<ablate::mathFunctions::MathFunction> boundaryFunction;
+
     //! precompute the region identifier for the boundary
     const static inline std::shared_ptr<ablate::domain::Region> shellBoundary = std::make_shared<ablate::domain::Region>("outerShell");
     const static inline std::shared_ptr<ablate::domain::Region> lowerCapBoundary = std::make_shared<ablate::domain::Region>("lowerCap");
@@ -75,7 +78,7 @@ class Axisymmetric : public ablate::domain::descriptions::MeshDescription {
      * @param numberShells slicing of the cylinder along the radius
      */
     Axisymmetric(std::shared_ptr<ablate::domain::descriptions::AxisDescription> axis, std::shared_ptr<ablate::mathFunctions::MathFunction> radiusFunction, PetscInt numberWedges,
-                 PetscInt numberShells);
+                 PetscInt numberShells, std::shared_ptr<ablate::mathFunctions::MathFunction> boundaryFunction);
 
     /**
      * The overall assumed dimension of the mesh

--- a/tests/unitTests/domain/descriptions/axisymmetricTests.cpp
+++ b/tests/unitTests/domain/descriptions/axisymmetricTests.cpp
@@ -5,7 +5,7 @@
 #include "mathFunctions/functionFactory.hpp"
 
 struct AxisymmetricMeshDescriptionParameters {
-    // Hold an mesh generator
+    // Hold a mesh generator
     std::shared_ptr<ablate::domain::descriptions::Axisymmetric> description;
 
     // Expected values
@@ -103,7 +103,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 1 slice, 1 shell
         AxisymmetricMeshDescriptionParameters{
             .description = std::make_shared<ablate::domain::descriptions::Axisymmetric>(std::make_shared<ablate::domain::descriptions::GeneratedAxis>(std::vector<PetscReal>{0.0, 0.0, 0.0}, 0.5, 2),
-                                                                                        ablate::mathFunctions::Create(1.0), 8, 1),
+                                                                                        ablate::mathFunctions::Create(1.0), 8, 1, ablate::mathFunctions::Create(1.0)),
             .expectedMeshDimension = 3,
             .expectedNumberCells = 8,
             .expectedNumberVertices = 18,
@@ -117,7 +117,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 2 slices, 1 shell
         AxisymmetricMeshDescriptionParameters{
             .description = std::make_shared<ablate::domain::descriptions::Axisymmetric>(std::make_shared<ablate::domain::descriptions::GeneratedAxis>(std::vector<PetscReal>{0.0, 0.0, 0.0}, 0.5, 3),
-                                                                                        ablate::mathFunctions::Create(1.0), 8, 1),
+                                                                                        ablate::mathFunctions::Create(1.0), 8, 1, ablate::mathFunctions::Create(1.0)),
             .expectedMeshDimension = 3,
             .expectedNumberCells = 16,
             .expectedNumberVertices = 27,
@@ -139,7 +139,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 1 slice, 2 shells
         AxisymmetricMeshDescriptionParameters{
             .description = std::make_shared<ablate::domain::descriptions::Axisymmetric>(std::make_shared<ablate::domain::descriptions::GeneratedAxis>(std::vector<PetscReal>{0.0, 0.0, 0.0}, 0.5, 2),
-                                                                                        ablate::mathFunctions::Create(1.0), 8, 2),
+                                                                                        ablate::mathFunctions::Create(1.0), 8, 2, ablate::mathFunctions::Create(1.0)),
             .expectedMeshDimension = 3,
             .expectedNumberCells = 16,
             .expectedNumberVertices = 34,
@@ -162,7 +162,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 2 slice, 2 shells
         AxisymmetricMeshDescriptionParameters{
             .description = std::make_shared<ablate::domain::descriptions::Axisymmetric>(std::make_shared<ablate::domain::descriptions::GeneratedAxis>(std::vector<PetscReal>{0.0, 0.0, 0.0}, 1.0, 3),
-                                                                                        ablate::mathFunctions::Create(1.0), 8, 2),
+                                                                                        ablate::mathFunctions::Create(1.0), 8, 2, ablate::mathFunctions::Create(1.0)),
             .expectedMeshDimension = 3,
             .expectedNumberCells = 32,
             .expectedNumberVertices = 51,
@@ -204,7 +204,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 2 slice, 2 shells, variable radius
         AxisymmetricMeshDescriptionParameters{
             .description = std::make_shared<ablate::domain::descriptions::Axisymmetric>(std::make_shared<ablate::domain::descriptions::GeneratedAxis>(std::vector<PetscReal>{0.0, 0.0, 0.0}, 2.0, 3),
-                                                                                        ablate::mathFunctions::Create(".1*z+ 0.5"), 8, 2),
+                                                                                        ablate::mathFunctions::Create(".1*z+ 0.5"), 8, 2, ablate::mathFunctions::Create(1.0)),
             .expectedMeshDimension = 3,
             .expectedNumberCells = 32,
             .expectedNumberVertices = 51,


### PR DESCRIPTION
Added in support for a user defined math function that can be used to label different boundary values on the outershell of an axisymmetric mesh based on the Z coordinate.