### PR TITLE
ablate.dev Github Action update

### DIFF
--- a/.github/workflows/PublishDoc.yaml
+++ b/.github/workflows/PublishDoc.yaml
@@ -57,7 +57,7 @@ jobs:
 
       # Upload all the artifacts
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:

--- a/.github/workflows/PublishDoc.yaml
+++ b/.github/workflows/PublishDoc.yaml
@@ -57,7 +57,7 @@ jobs:
 
       # Upload all the artifacts
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.18.4)
 include(config/petscCompilers.cmake)
 
 # Set the project details
-project(ablateLibrary VERSION 0.13.00)
+project(ablateLibrary VERSION 0.13.01)
 
 # Load the Required 3rd Party Libaries
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET GLOBAL PETSc)


### PR DESCRIPTION
actions/upload-pages-artifact@v1 is no longer just deprecated so switching to the most recent version so the github action works.